### PR TITLE
Write new kernel physical and virtual memory managers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 
 script:
   - make
+  - cargo test --features arch_x86_64 --manifest-path kernel/Cargo.toml
   - make doc
 
 branches:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ bootloader:
 	cp bootloader/target/uefi_x64/release/bootloader.efi $(BUILD_DIR)/fat/EFI/BOOT/BOOTX64.efi
 
 kernel:
-	cargo xbuild --target=kernel/src/$(ARCH)/$(ARCH)-kernel.json --manifest-path kernel/Cargo.toml --features $(ARCH)
+	cargo xbuild --target=kernel/src/$(ARCH)/$(ARCH)-kernel.json --manifest-path kernel/Cargo.toml --features arch_$(ARCH)
 	ld --gc-sections -T kernel/src/$(ARCH)/link.ld -o $(BUILD_DIR)/fat/kernel.elf kernel/target/$(ARCH)-kernel/debug/libkernel.a
 
 clean:

--- a/bootloader/src/boot_services/memory.rs
+++ b/bootloader/src/boot_services/memory.rs
@@ -18,7 +18,7 @@ impl BootServices {
     pub fn allocate_frames(
         &self,
         memory_type: MemoryType,
-        pages: u64,
+        pages: usize,
     ) -> Result<PhysicalAddress, Status> {
         let mut start_address = PhysicalAddress::default();
         match (self._allocate_pages)(
@@ -35,7 +35,7 @@ impl BootServices {
     }
 
     /// Frees memory pages
-    pub fn free_pages(&self, memory: PhysicalAddress, pages: u64) -> Result<(), Status> {
+    pub fn free_pages(&self, memory: PhysicalAddress, pages: usize) -> Result<(), Status> {
         (self._free_pages)(memory, pages).as_result().map(|_| ())
     }
 

--- a/bootloader/src/boot_services/memory.rs
+++ b/bootloader/src/boot_services/memory.rs
@@ -21,7 +21,14 @@ impl BootServices {
         pages: u64,
     ) -> Result<PhysicalAddress, Status> {
         let mut start_address = PhysicalAddress::default();
-        match (self._allocate_pages)(AllocateType::AllocateAnyPages, memory_type, pages, &mut start_address).as_result() {
+        match (self._allocate_pages)(
+            AllocateType::AllocateAnyPages,
+            memory_type,
+            pages,
+            &mut start_address,
+        )
+        .as_result()
+        {
             Ok(_) => Ok(start_address),
             Err(err) => Err(err),
         }

--- a/bootloader/src/boot_services/memory.rs
+++ b/bootloader/src/boot_services/memory.rs
@@ -14,21 +14,21 @@ pub enum AllocateType {
 }
 
 impl BootServices {
-    /// Allocates memory pages from the system
-    pub fn allocate_pages(
+    /// Allocates memory frames from the system
+    pub fn allocate_frames(
         &self,
-        allocation_type: AllocateType,
         memory_type: MemoryType,
-        pages: usize,
-        memory: &mut PhysicalAddress,
-    ) -> Result<(), Status> {
-        (self._allocate_pages)(allocation_type, memory_type, pages, memory)
-            .as_result()
-            .map(|_| ())
+        pages: u64,
+    ) -> Result<PhysicalAddress, Status> {
+        let mut start_address = PhysicalAddress::default();
+        match (self._allocate_pages)(AllocateType::AllocateAnyPages, memory_type, pages, &mut start_address).as_result() {
+            Ok(_) => Ok(start_address),
+            Err(err) => Err(err),
+        }
     }
 
     /// Frees memory pages
-    pub fn free_pages(&self, memory: PhysicalAddress, pages: usize) -> Result<(), Status> {
+    pub fn free_pages(&self, memory: PhysicalAddress, pages: u64) -> Result<(), Status> {
         (self._free_pages)(memory, pages).as_result().map(|_| ())
     }
 

--- a/bootloader/src/boot_services/mod.rs
+++ b/bootloader/src/boot_services/mod.rs
@@ -30,10 +30,10 @@ pub struct BootServices {
     pub _allocate_pages: extern "win64" fn(
         allocation_type: AllocateType,
         memory_type: MemoryType,
-        pages: usize,
+        pages: u64,
         memory: &mut PhysicalAddress,
     ) -> Status,
-    pub _free_pages: extern "win64" fn(memory: PhysicalAddress, pages: usize) -> Status,
+    pub _free_pages: extern "win64" fn(memory: PhysicalAddress, pages: u64) -> Status,
     pub _get_memory_map: extern "win64" fn(
         memory_map_size: &mut usize,
         memory_map: *mut MemoryDescriptor,

--- a/bootloader/src/boot_services/mod.rs
+++ b/bootloader/src/boot_services/mod.rs
@@ -30,10 +30,10 @@ pub struct BootServices {
     pub _allocate_pages: extern "win64" fn(
         allocation_type: AllocateType,
         memory_type: MemoryType,
-        pages: u64,
+        pages: usize,
         memory: &mut PhysicalAddress,
     ) -> Status,
-    pub _free_pages: extern "win64" fn(memory: PhysicalAddress, pages: u64) -> Status,
+    pub _free_pages: extern "win64" fn(memory: PhysicalAddress, pages: usize) -> Status,
     pub _get_memory_map: extern "win64" fn(
         memory_map_size: &mut usize,
         memory_map: *mut MemoryDescriptor,

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -18,7 +18,7 @@ mod runtime_services;
 mod system_table;
 mod types;
 
-use crate::boot_services::{AllocateType, OpenProtocolAttributes, Pool, Protocol, SearchType};
+use crate::boot_services::{OpenProtocolAttributes, Pool, Protocol, SearchType};
 use crate::memory::{BootFrameAllocator, MemoryMap, MemoryType};
 use crate::protocols::{FileAttributes, FileInfo, FileMode, FileSystemInfo, SimpleFileSystem};
 use crate::system_table::SystemTable;

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -185,19 +185,16 @@ fn setup_for_kernel() {
 
 fn create_page_table() -> InactivePageTable<IdentityMapping> {
     // Allocate a frame for the P4
-    let mut address = PhysicalAddress::default();
-    match system_table().boot_services.allocate_pages(
-        AllocateType::AllocateAnyPages,
+    let address = match system_table().boot_services.allocate_frames(
         MemoryType::PebblePageTables,
         1,
-        &mut address,
     ) {
-        Ok(()) => {}
+        Ok(address) => address,
         Err(err) => panic!(
             "Failed to allocate physical memory for page tables: {:?}",
             err
         ),
-    }
+    };
 
     // Zero the P4 to mark every entry as non-present
     unsafe {
@@ -243,16 +240,13 @@ fn load_kernel(
     }
 
     // Allocate physical memory for the kernel
-    let mut kernel_physical_base = PhysicalAddress::default();
-    match system_table().boot_services.allocate_pages(
-        AllocateType::AllocateAnyPages,
+    let kernel_physical_base = match system_table().boot_services.allocate_frames(
         MemoryType::PebbleKernelMemory,
-        (kernel_size / FRAME_SIZE) as usize,
-        &mut kernel_physical_base,
+        kernel_size / FRAME_SIZE,
     ) {
-        Ok(()) => {}
+        Ok(address) => address,
         Err(err) => panic!("Failed to allocate physical memory for kernel: {:?}", err),
-    }
+    };
 
     // We now zero all the kernel memory
     unsafe {

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -19,18 +19,19 @@ mod system_table;
 mod types;
 
 use crate::boot_services::{AllocateType, OpenProtocolAttributes, Pool, Protocol, SearchType};
-use crate::memory::{BootFrameAllocator, MemoryType};
+use crate::memory::{BootFrameAllocator, MemoryMap, MemoryType};
 use crate::protocols::{FileAttributes, FileInfo, FileMode, FileSystemInfo, SimpleFileSystem};
 use crate::system_table::SystemTable;
 use crate::types::{Handle, Status};
 use core::fmt::Write;
+use core::mem;
 use core::panic::PanicInfo;
 use core::slice;
 use mer::{
     section::{SectionHeader, SectionType},
     Elf,
 };
-use x86_64::boot::BootInfo;
+use x86_64::boot::{BootInfo, MemoryEntry, MemoryType as BootInfoMemoryType};
 use x86_64::hw::registers::{read_control_reg, read_msr, write_control_reg, write_msr};
 use x86_64::hw::serial::SerialPort;
 use x86_64::memory::kernel_map;
@@ -82,30 +83,33 @@ pub extern "win64" fn uefi_main(image_handle: Handle, system_table: &'static Sys
     /*
      * Allocate physical memory for the kernel heap, and map it into the kernel page tables.
      */
-    println!("Allocating memory for kernel heap");
-    assert!(kernel_map::HEAP_START.is_page_aligned());
-    assert!((kernel_map::HEAP_END + 1).unwrap().is_page_aligned());
-    let heap_size = (usize::from(kernel_map::HEAP_END) + 1) - usize::from(kernel_map::HEAP_START);
-    assert!(heap_size % FRAME_SIZE == 0);
-    let heap_physical_base = match system_table
+    allocate_and_map_heap(&mut mapper, &allocator);
+
+    /*
+     * Allocate space for the `BootInfo`. We allocate a single frame for it, so make sure it'll
+     * fit.
+     */
+    assert!(mem::size_of::<BootInfo>() <= FRAME_SIZE);
+    let boot_info_address = match system_table
         .boot_services
-        .allocate_frames(MemoryType::PebbleKernelHeap, heap_size / FRAME_SIZE)
+        .allocate_frames(MemoryType::PebbleBootInformation, 1)
     {
         Ok(address) => address,
-        Err(err) => panic!("Failed to allocate memory for kernel heap: {:?}", err),
+        Err(err) => panic!("Failed to allocate memory for the boot info: {:?}", err),
     };
+    let boot_info = unsafe { &mut *(usize::from(boot_info_address) as *mut BootInfo) };
+    boot_info.magic = x86_64::boot::BOOT_INFO_MAGIC;
+    boot_info.num_memory_map_entries = 0;
 
-    let heap_frames = Frame::contains(heap_physical_base)
-        ..=Frame::contains((heap_physical_base + heap_size).unwrap());
-    let heap_pages = Page::contains(kernel_map::HEAP_START)..=Page::contains(kernel_map::HEAP_END);
-    for (frame, page) in heap_frames.zip(heap_pages) {
-        mapper.map_to(
-            page,
-            frame,
-            EntryFlags::PRESENT | EntryFlags::WRITABLE | EntryFlags::NO_EXECUTE,
-            &allocator,
-        );
-    }
+    /*
+     * Map the `BootInfo` into the kernel address space at the correct location.
+     */
+    mapper.map_to(
+        Page::contains(kernel_map::BOOT_INFO),
+        Frame::contains(boot_info_address),
+        EntryFlags::PRESENT | EntryFlags::NO_EXECUTE,
+        &allocator,
+    );
 
     /*
      * Get the final memory map before exiting boot services. We must not allocate between this
@@ -116,12 +120,13 @@ pub extern "win64" fn uefi_main(image_handle: Handle, system_table: &'static Sys
         Err(err) => panic!("Failed to get memory map: {:?}", err),
     };
 
+    construct_boot_info(boot_info, &memory_map);
+
     /*
-     * Identity-map the bootloader and UEFI runtime stuff into the kernel address space. This is
-     * needed so we don't page fault when we switch to the new page tables, and so we can still use
-     * runtime services.
+     * Identity map the bootloader code and data, and UEFI runtime services into the kernel
+     * address space. This is needed so we don't page-fault when we switch page tables.
      *
-     * TODO: why do we need boot services code mapped after we've exited them??
+     * TODO: why do we still need boot services code mapped after calling ExitBootServices?!
      */
     for entry in memory_map.iter() {
         match entry.memory_type {
@@ -231,12 +236,110 @@ fn create_page_table() -> InactivePageTable<IdentityMapping> {
 
     // Zero the P4 to mark every entry as non-present
     unsafe {
-        system_table()
-            .boot_services
-            .set_mem(usize::from(address) as *mut _, FRAME_SIZE as usize, 0);
+        system_table().boot_services.set_mem(
+            usize::from(address) as *mut _,
+            FRAME_SIZE as usize,
+            0,
+        );
     }
 
     InactivePageTable::new(Frame::contains(address))
+}
+
+fn allocate_and_map_heap(mapper: &mut Mapper<IdentityMapping>, allocator: &BootFrameAllocator) {
+    println!("Allocating memory for kernel heap");
+
+    assert!(kernel_map::HEAP_START.is_page_aligned());
+    assert!((kernel_map::HEAP_END + 1).unwrap().is_page_aligned());
+    let heap_size = (usize::from(kernel_map::HEAP_END) + 1) - usize::from(kernel_map::HEAP_START);
+    assert!(heap_size % FRAME_SIZE == 0);
+    let heap_physical_base = match system_table()
+        .boot_services
+        .allocate_frames(MemoryType::PebbleKernelHeap, heap_size / FRAME_SIZE)
+    {
+        Ok(address) => address,
+        Err(err) => panic!("Failed to allocate memory for kernel heap: {:?}", err),
+    };
+
+    let heap_frames = Frame::contains(heap_physical_base)
+        ..=Frame::contains((heap_physical_base + heap_size).unwrap());
+    let heap_pages = Page::contains(kernel_map::HEAP_START)..=Page::contains(kernel_map::HEAP_END);
+    for (frame, page) in heap_frames.zip(heap_pages) {
+        mapper.map_to(
+            page,
+            frame,
+            EntryFlags::PRESENT | EntryFlags::WRITABLE | EntryFlags::NO_EXECUTE,
+            allocator,
+        );
+    }
+}
+
+fn construct_boot_info(boot_info: &mut BootInfo, memory_map: &MemoryMap) {
+    println!("Constructing boot info to pass to kernel");
+
+    for entry in memory_map.iter() {
+        let memory_type = match entry.memory_type {
+            // Keep the UEFI runtime services stuff around - anything might be using them.
+            MemoryType::RuntimeServicesCode | MemoryType::RuntimeServicesData => {
+                BootInfoMemoryType::UefiServices
+            }
+
+            /*
+             * The bootloader and boot services code and data can be treated like conventional RAM
+             * once we're in the kernel.
+             */
+            MemoryType::LoaderCode
+            | MemoryType::LoaderData
+            | MemoryType::BootServicesCode
+            | MemoryType::BootServicesData
+            | MemoryType::ConventionalMemory => BootInfoMemoryType::Conventional,
+
+            /*
+             * This memory must not be used until we're done with the ACPI tables, and then can be
+             * used as conventional memory.
+             */
+            MemoryType::ACPIReclaimMemory => BootInfoMemoryType::AcpiReclaimable,
+
+            MemoryType::ACPIMemoryNVS | MemoryType::PersistentMemory => {
+                BootInfoMemoryType::SleepPreserve
+            }
+
+            MemoryType::PalCode => BootInfoMemoryType::NonVolatileSleepPreserve,
+
+            /*
+             * These types of memory should not be used by the OS, so we don't emit an entry for
+             * them.
+             */
+            MemoryType::ReservedMemoryType
+            | MemoryType::MemoryMappedIO
+            | MemoryType::MemoryMappedIOPortSpace
+            | MemoryType::UnusableMemory => continue,
+
+            /*
+             * These are the memory regions we're allocated for the kernel. We just forward them on
+             * in the kernel memory map entries.
+             */
+            MemoryType::PebbleKernelMemory => BootInfoMemoryType::KernelImage,
+            MemoryType::PebblePageTables => BootInfoMemoryType::KernelPageTables,
+            MemoryType::PebbleBootInformation => BootInfoMemoryType::BootInfo,
+            MemoryType::PebbleKernelHeap => BootInfoMemoryType::KernelHeap,
+
+            MemoryType::MaxMemoryType => panic!("Invalid memory type found in UEFI memory map!"),
+        };
+
+        let start_frame = Frame::contains(entry.physical_start);
+        let bootinfo_entry = MemoryEntry {
+            area: start_frame..(start_frame + entry.number_of_pages as usize),
+            memory_type,
+        };
+
+        if boot_info.num_memory_map_entries == x86_64::boot::MEMORY_MAP_NUM_ENTRIES {
+            panic!("Run out of space for memory map entries in the BootInfo!");
+        }
+
+        boot_info.memory_map[boot_info.num_memory_map_entries] = bootinfo_entry;
+        boot_info.num_memory_map_entries += 1;
+    }
 }
 
 /// Load the kernel's sections into memory and return the entry point
@@ -384,10 +487,10 @@ fn map_section(
      * ranges `[physical_base, physical_base + size)` and `[virtual_address, virtual_address +
      * size)` gives us the correct frame and page ranges.
      */
-    let frames =
-        Frame::contains(physical_base)..Frame::contains((physical_base + section.size as usize).unwrap());
-    let pages =
-        Page::contains(virtual_address)..Page::contains((virtual_address + section.size as usize).unwrap());
+    let frames = Frame::contains(physical_base)
+        ..Frame::contains((physical_base + section.size as usize).unwrap());
+    let pages = Page::contains(virtual_address)
+        ..Page::contains((virtual_address + section.size as usize).unwrap());
     assert!(frames.clone().count() == pages.clone().count());
 
     /*

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -82,6 +82,7 @@ pub extern "win64" fn uefi_main(image_handle: Handle, system_table: &'static Sys
     /*
      * Allocate physical memory for the kernel heap, and map it into the kernel page tables.
      */
+    println!("Allocating memory for kernel heap");
     assert!(kernel_map::HEAP_START.is_page_aligned());
     assert!((kernel_map::HEAP_END + 1).unwrap().is_page_aligned());
     let heap_size = (u64::from(kernel_map::HEAP_END) + 1) - u64::from(kernel_map::HEAP_START);

--- a/bootloader/src/memory.rs
+++ b/bootloader/src/memory.rs
@@ -1,4 +1,3 @@
-use crate::boot_services::AllocateType;
 use crate::system_table;
 use core::cell::Cell;
 use core::ops::{Index, Range};
@@ -52,7 +51,7 @@ impl BootFrameAllocator {
 }
 
 impl FrameAllocator for BootFrameAllocator {
-    fn allocate_n(&self, n: usize) -> Result<Range<Frame>, !> {
+    fn allocate_n(&self, n: usize) -> Range<Frame> {
         if (self.next_frame.get() + n) > self.end_frame {
             panic!("Bootloader frame allocator ran out of frames!");
         }
@@ -60,10 +59,10 @@ impl FrameAllocator for BootFrameAllocator {
         let frame = self.next_frame.get();
         self.next_frame.update(|frame| frame + n);
 
-        Ok(frame..(frame + n))
+        frame..(frame + n)
     }
 
-    fn free(&self, _: Frame) {
+    fn free_n(&self, _: Frame, _: usize) {
         /*
          * NOTE: We should only free physical memory in the bootloader when we unmap the stack guard
          * page. Because of the simplicity of our allocator, we can't do anything useful with the

--- a/bootloader/src/memory.rs
+++ b/bootloader/src/memory.rs
@@ -23,16 +23,15 @@ pub struct BootFrameAllocator {
 
 impl BootFrameAllocator {
     pub fn new(num_frames: u64) -> BootFrameAllocator {
-        let mut start_frame_address = PhysicalAddress::default();
-        system_table()
+        let start_frame_address = match system_table()
             .boot_services
-            .allocate_pages(
-                AllocateType::AllocateAnyPages,
+            .allocate_frames(
                 MemoryType::PebblePageTables,
-                num_frames as usize,
-                &mut start_frame_address,
-            )
-            .unwrap();
+                num_frames,
+            ) {
+                Ok(address) => address,
+                Err(err) => panic!("Failed to allocate memory for page frame allocator: {:?}", err),
+            };
 
         // Zero all the memory so the page tables start with everything unmapped
         unsafe {
@@ -179,4 +178,5 @@ pub enum MemoryType {
     PebbleKernelMemory = 0x8000_0000,
     PebblePageTables = 0x8000_0001,
     PebbleBootInformation = 0x8000_0002,
+    PebbleKernelHeap = 0x8000_0003,
 }

--- a/bootloader/src/memory.rs
+++ b/bootloader/src/memory.rs
@@ -22,7 +22,7 @@ pub struct BootFrameAllocator {
 }
 
 impl BootFrameAllocator {
-    pub fn new(num_frames: u64) -> BootFrameAllocator {
+    pub fn new(num_frames: usize) -> BootFrameAllocator {
         let start_frame_address = match system_table()
             .boot_services
             .allocate_frames(MemoryType::PebblePageTables, num_frames)
@@ -37,7 +37,7 @@ impl BootFrameAllocator {
         // Zero all the memory so the page tables start with everything unmapped
         unsafe {
             system_table().boot_services.set_mem(
-                u64::from(start_frame_address) as *mut _,
+                usize::from(start_frame_address) as *mut _,
                 (num_frames * FRAME_SIZE) as usize,
                 0,
             );
@@ -52,7 +52,7 @@ impl BootFrameAllocator {
 }
 
 impl FrameAllocator for BootFrameAllocator {
-    fn allocate_n(&self, n: u64) -> Result<Range<Frame>, !> {
+    fn allocate_n(&self, n: usize) -> Result<Range<Frame>, !> {
         if (self.next_frame.get() + n) > self.end_frame {
             panic!("Bootloader frame allocator ran out of frames!");
         }

--- a/bootloader/src/memory.rs
+++ b/bootloader/src/memory.rs
@@ -25,13 +25,14 @@ impl BootFrameAllocator {
     pub fn new(num_frames: u64) -> BootFrameAllocator {
         let start_frame_address = match system_table()
             .boot_services
-            .allocate_frames(
-                MemoryType::PebblePageTables,
-                num_frames,
-            ) {
-                Ok(address) => address,
-                Err(err) => panic!("Failed to allocate memory for page frame allocator: {:?}", err),
-            };
+            .allocate_frames(MemoryType::PebblePageTables, num_frames)
+        {
+            Ok(address) => address,
+            Err(err) => panic!(
+                "Failed to allocate memory for page frame allocator: {:?}",
+                err
+            ),
+        };
 
         // Zero all the memory so the page tables start with everything unmapped
         unsafe {

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.1.0",
 ]
@@ -32,6 +33,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "spin"
@@ -51,4 +57,5 @@ dependencies = [
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -11,6 +11,11 @@ crate-type = ["staticlib"]
 cfg-if = "0.1"
 bitflags = "1"
 bit_field = "0.9"
+num-traits = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
 spin = "0.4"
 x86_64 = { path = "../x86_64", optional = true }
+
+[features]
+arch_x86_64 = ["x86_64"]
+tuning-fast_ctlz = []

--- a/kernel/src/heap_allocator.rs
+++ b/kernel/src/heap_allocator.rs
@@ -178,7 +178,9 @@ fn split_hole(hole: HoleInfo, required_layout: Layout) -> Option<Allocation> {
          * We need to add front padding to correctly align the data
          * in the hole.
          */
-        let aligned_addr = (hole.addr + HoleList::get_min_size()).unwrap().align_up(required_align);
+        let aligned_addr = (hole.addr + HoleList::get_min_size())
+            .unwrap()
+            .align_up(required_align);
 
         (
             aligned_addr,

--- a/kernel/src/heap_allocator.rs
+++ b/kernel/src/heap_allocator.rs
@@ -1,0 +1,389 @@
+/*
+ * TODO: in the future, it'd be great to re-write this to be slightly more type-safe and use the
+ * nice address types, but we need to think more about how to mix `u64` and `usize` without
+ * creating a mess.
+ */
+
+use core::alloc::{AllocErr, GlobalAlloc, Layout};
+use core::cmp::max;
+use core::mem::{self, size_of};
+use core::ops::Deref;
+use spin::Mutex;
+use x86_64::memory::VirtualAddress;
+
+pub struct HoleAllocator {
+    heap_bottom: usize,
+    heap_size: usize,
+    holes: Option<HoleList>,
+}
+
+impl HoleAllocator {
+    /// Create a new, uninitialized `HoleAllocator`. Before heap allocations can be made, `init`
+    /// must be called.
+    pub const fn new_uninitialized() -> HoleAllocator {
+        HoleAllocator {
+            heap_bottom: 0,
+            heap_size: 0,
+            holes: None,
+        }
+    }
+
+    /// Initialise the `HoleAllocator`. This should only be called once, and constructs the
+    /// `HoleList` from the address range.
+    pub unsafe fn init(&mut self, heap_bottom: VirtualAddress, heap_top: VirtualAddress) {
+        assert!(self.holes.is_none());
+        self.heap_bottom = u64::from(heap_bottom) as usize;
+        self.heap_size = u64::from(heap_top) as usize - self.heap_bottom;
+        self.holes = Some(HoleList::new(self.heap_bottom, self.heap_size));
+    }
+}
+
+pub struct LockedHoleAllocator(Mutex<HoleAllocator>);
+
+impl LockedHoleAllocator {
+    pub const fn new_uninitialized() -> LockedHoleAllocator {
+        LockedHoleAllocator(Mutex::new(HoleAllocator::new_uninitialized()))
+    }
+}
+
+impl Deref for LockedHoleAllocator {
+    type Target = Mutex<HoleAllocator>;
+
+    fn deref(&self) -> &Mutex<HoleAllocator> {
+        &self.0
+    }
+}
+
+unsafe impl GlobalAlloc for LockedHoleAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let size = align_up(
+            max(layout.size(), HoleList::get_min_size()),
+            mem::align_of::<Hole>(),
+        );
+        let layout = Layout::from_size_align(size, layout.align()).unwrap();
+
+        match self.0.lock().holes {
+            Some(ref mut holes) => holes.allocate_first_fit(layout).unwrap_or(0x0 as *mut u8),
+            None => panic!("Tried to allocate on the heap before initializing allocator!"),
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        let size = align_up(
+            max(layout.size(), HoleList::get_min_size()),
+            mem::align_of::<Hole>(),
+        );
+        let layout = Layout::from_size_align(size, layout.align()).unwrap();
+
+        match self.0.lock().holes {
+            Some(ref mut holes) => holes.free(ptr, layout),
+            None => panic!("Tried to allocate on the heap before initializing allocator!"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct HoleInfo {
+    addr: usize,
+    size: usize,
+}
+
+pub struct Hole {
+    size: usize,
+    next: Option<&'static mut Hole>,
+}
+
+impl Hole {
+    fn info(&self) -> HoleInfo {
+        HoleInfo {
+            addr: self as *const _ as usize,
+            size: self.size,
+        }
+    }
+}
+
+pub struct HoleList {
+    first: Hole,
+}
+
+impl HoleList {
+    /// Create a new `HoleList` that contains the given hole. Unsafe because it is undefined
+    /// bahaviour if the address passes is invalid or if [hole_addr, hole_addr+size) is used
+    /// somewhere.
+    pub unsafe fn new(hole_addr: usize, hole_size: usize) -> HoleList {
+        assert!(size_of::<Hole>() == Self::get_min_size());
+
+        let ptr = hole_addr as *mut Hole;
+        mem::replace(
+            &mut *ptr,
+            Hole {
+                size: hole_size,
+                next: None,
+            },
+        );
+
+        HoleList {
+            first: Hole {
+                size: 0,
+                next: Some(&mut *ptr),
+            },
+        }
+    }
+
+    /// Search for a big enough hole for the given `Layout` with its required alignment. This uses
+    /// the first-fit strategy, and so is O(n)
+    pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
+        assert!(layout.size() >= Self::get_min_size());
+
+        allocate_first_fit(&mut self.first, layout).map(|allocation| {
+            if let Some(padding) = allocation.front_padding {
+                free(&mut self.first, padding.addr, padding.size);
+            }
+
+            if let Some(padding) = allocation.back_padding {
+                free(&mut self.first, padding.addr, padding.size);
+            }
+
+            allocation.info.addr as *mut u8
+        })
+    }
+
+    /// Free an allocation defined by `ptr` and `layout`. Unsafe because if `ptr` was not returned
+    /// by a call to `allocate_first_fit`, undefined behaviour may occur. Deallocates by walking the
+    /// list and inserts the given hole at the correct position. If the freed block is adjacent to
+    /// another one, they are merged.
+    pub unsafe fn free(&mut self, ptr: *mut u8, layout: Layout) {
+        free(&mut self.first, ptr as usize, layout.size());
+    }
+
+    pub fn get_min_size() -> usize {
+        size_of::<usize>() * 2
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Allocation {
+    info: HoleInfo,
+    front_padding: Option<HoleInfo>,
+    back_padding: Option<HoleInfo>,
+}
+
+/*
+ * Split the given hole into (front_padding,hole,back_padding) if it's big enough to hold the given
+ * layout with the required alignment.
+ *      - Front padding occurs when the required alignment is higher than that of the hole.
+ *      - Back padding occurs when the layout's size is smaller than the hole.
+ */
+fn split_hole(hole: HoleInfo, required_layout: Layout) -> Option<Allocation> {
+    let required_size = required_layout.size();
+    let required_align = required_layout.align();
+
+    let (aligned_addr, front_pad) = if hole.addr == align_up(hole.addr, required_align) {
+        (hole.addr, None) // Hole already has correct alignment
+    } else {
+        /*
+         * We need to add front padding to correctly align the data
+         * in the hole.
+         */
+        let aligned_addr = align_up(hole.addr + HoleList::get_min_size(), required_align);
+
+        (
+            aligned_addr,
+            Some(HoleInfo {
+                addr: hole.addr,
+                size: aligned_addr - hole.addr,
+            }),
+        )
+    };
+
+    let aligned_hole = if aligned_addr + required_size > hole.addr + hole.size {
+        return None; // Hole is too small
+    } else {
+        HoleInfo {
+            addr: aligned_addr,
+            size: hole.size - (aligned_addr - hole.addr),
+        }
+    };
+
+    let back_pad = if aligned_hole.size == required_size {
+        None // Exactly the right size, don't add back padding
+    } else if (aligned_hole.size - required_size) < HoleList::get_min_size() {
+        return None; // We can't use this hole; it would leave a too small new one
+    } else {
+        /*
+         * The hole is too big for the allocation, so add some back padding to
+         * use the extra space.
+         */
+        Some(HoleInfo {
+            addr: aligned_hole.addr + required_size,
+            size: aligned_hole.size - required_size,
+        })
+    };
+
+    Some(Allocation {
+        info: HoleInfo {
+            addr: aligned_hole.addr,
+            size: required_size,
+        },
+        front_padding: front_pad,
+        back_padding: back_pad,
+    })
+}
+
+fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocation, AllocErr> {
+    loop {
+        let allocation: Option<Allocation> = previous
+            .next
+            .as_mut()
+            .and_then(|current| split_hole(current.info(), layout.clone()));
+
+        match allocation {
+            Some(allocation) => {
+                // Remove the allocated hole from the list
+                previous.next = previous.next.as_mut().unwrap().next.take();
+                return Ok(allocation);
+            }
+
+            None if previous.next.is_some() => {
+                // Try the next hole
+                // XXX: `{x}` forces the reference `x` to move instead of be reborrowed
+                previous = { previous }.next.as_mut().unwrap();
+            }
+
+            None => {
+                // This is the last hole, so no hole is big enough for this allocation :(
+                return Err(AllocErr {});
+            }
+        }
+    }
+}
+
+/*
+ * Walk the list, starting at `hole` and free the allocation given by `(addr,size)`
+ */
+fn free(mut hole: &mut Hole, addr: usize, mut size: usize) {
+    loop {
+        assert!(size >= HoleList::get_min_size());
+
+        /*
+         * If the size is 0, it's the dummy hole, so just set the address to 0
+         */
+        let hole_addr = if hole.size == 0 {
+            0
+        } else {
+            (hole as *mut _) as usize
+        };
+        assert!(
+            hole_addr + hole.size <= addr,
+            "Invalid deallocation (probable double free)"
+        );
+        let next_hole_info = hole.next.as_ref().map(|next| next.info());
+
+        match next_hole_info {
+            Some(next) if hole_addr + hole.size == addr && addr + size == next.addr => {
+                /*
+                 * The block exactly fills the gap between this hole and the next:
+                 *      Before: ___XXX____YYYY___    (X=this hole, Y=next hole)
+                 *      After : ___XXXFFFFYYYY___    (F=freed block)
+                 */
+                hole.size += size; // Merge F into X
+                hole.size += next.size; // Merge Y into X
+                hole.next = hole.next.as_mut().unwrap().next.take(); // Remove Y
+            }
+
+            _ if hole_addr + hole.size == addr => {
+                /*
+                 * The block is right behind this hole but there is used memory after it:
+                 *      Before: ___XXX______YYYY___ (X=this hole, Y=next hole)
+                 *      After : ___XXXFFFF__YYYY___ (F=freed block)
+                 *
+                 * Or block is right behind this hole and this is the last hole:
+                 *      Before: ___XXX_____________
+                 *      After : ___XXXFFFF_________
+                 */
+                hole.size += size; // Merge F into X
+            }
+
+            Some(next) if addr + size == next.addr => {
+                /*
+                 * The block is right before the next hole but there is used memory before it:
+                 *      Before: ___XXX______YYYY___
+                 *      After : ___XXX__FFFFYYYY___
+                 */
+                hole.next = hole.next.as_mut().unwrap().next.take(); // Remove Y
+                size += next.size; // Free the merged F/Y block
+                continue;
+            }
+
+            Some(next) if next.addr <= addr => {
+                /*
+                 * The block is behind the next hole, so delegate it to the next hole
+                 *      Before: ___XXX___YYYY________
+                 *      After : ___XXX___YYYY__FFFF__
+                 */
+                hole = { hole }.next.as_mut().unwrap(); // Start next iteration at next hole
+                continue;
+            }
+
+            _ => {
+                /*
+                 * The block is between this and the next hole:
+                 *      Before: ___XXX________YYYY___
+                 *      After : ___XXX__FFFF__YYYY___
+                 *
+                 *  Or this is the last hole:
+                 *      Before: ___XXX________
+                 *      After : ___XXX__FFFF__
+                 */
+                let new_hole = Hole {
+                    size: size,
+                    next: hole.next.take(), // Ref to Y (if it exists)
+                };
+
+                // Write the new hole into the freed memory block
+                let ptr = addr as *mut Hole;
+                unsafe {
+                    ptr.write(new_hole);
+                }
+
+                // Add F as the next block of X
+                hole.next = Some(unsafe { &mut *ptr });
+            }
+        }
+        break;
+    }
+}
+
+/// Get the greatest x with the given alignment such that x <= the given address. The alignment
+/// must be a power of two.
+pub fn align_down(addr: usize, align: usize) -> usize {
+    assert!(
+        align == 0 || align.is_power_of_two(),
+        "Can only align to a power of two"
+    );
+
+    if align.is_power_of_two() {
+        /*
+         * E.g.
+         *      align       =   0b00001000
+         *      align-1     =   0b00000111
+         *      !(align-1)  =   0b11111000
+         *                             ^^^ Masks the address to the value below it with the
+         *                                 correct alignment
+         */
+        addr & !(align - 1)
+    } else {
+        assert!(align == 0);
+        addr
+    }
+}
+
+/// Get the smallest x with the given alignment such that x >= the given address.
+pub fn align_up(addr: usize, align: usize) -> usize {
+    align_down(addr + align - 1, align)
+}
+
+#[alloc_error_handler]
+fn handle_alloc_error(layout: Layout) -> ! {
+    panic!("Alloc error: {:?}", layout);
+}

--- a/kernel/src/heap_allocator.rs
+++ b/kernel/src/heap_allocator.rs
@@ -376,6 +376,7 @@ pub fn align_up(addr: usize, align: usize) -> usize {
     align_down(addr + align - 1, align)
 }
 
+#[cfg(not(test))]
 #[alloc_error_handler]
 fn handle_alloc_error(layout: Layout) -> ! {
     panic!("Alloc error: {:?}", layout);

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![feature(asm, decl_macro, allocator_api, const_fn, alloc, alloc_error_handler)]
 extern crate alloc;
 
@@ -22,9 +22,11 @@ use cfg_if::cfg_if;
 use core::panic::PanicInfo;
 use log::error;
 
+#[cfg(not(test))]
 #[global_allocator]
 pub static ALLOCATOR: LockedHoleAllocator = LockedHoleAllocator::new_uninitialized();
 
+#[cfg(not(test))]
 #[panic_handler]
 #[no_mangle]
 fn panic(info: &PanicInfo) -> ! {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -20,12 +20,16 @@ mod heap_allocator;
 use crate::heap_allocator::LockedHoleAllocator;
 use cfg_if::cfg_if;
 use core::panic::PanicInfo;
+use log::error;
+
 #[global_allocator]
 pub static ALLOCATOR: LockedHoleAllocator = LockedHoleAllocator::new_uninitialized();
 
 #[panic_handler]
 #[no_mangle]
-pub extern "C" fn panic(info: &PanicInfo) -> ! {
-    // TODO
-    loop {}
+fn panic(info: &PanicInfo) -> ! {
+    error!("KERNEL PANIC: {}", info);
+    loop {
+        // TODO: arch-independent cpu halt?
+    }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), no_std)]
-#![feature(asm, decl_macro, allocator_api, const_fn, alloc, alloc_error_handler)]
+#![feature(asm, decl_macro, allocator_api, const_fn, alloc, alloc_error_handler, core_intrinsics)]
 extern crate alloc;
 
 /*
@@ -8,7 +8,7 @@ extern crate alloc;
  * code.
  */
 cfg_if! {
-    if #[cfg(feature = "x86_64")] {
+    if #[cfg(feature = "arch_x86_64")] {
         mod x86_64;
         pub use crate::x86_64::kmain;
     } else {
@@ -17,6 +17,8 @@ cfg_if! {
 }
 
 mod heap_allocator;
+mod util;
+
 use crate::heap_allocator::LockedHoleAllocator;
 use cfg_if::cfg_if;
 use core::panic::PanicInfo;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,5 +1,13 @@
 #![cfg_attr(not(test), no_std)]
-#![feature(asm, decl_macro, allocator_api, const_fn, alloc, alloc_error_handler, core_intrinsics)]
+#![feature(
+    asm,
+    decl_macro,
+    allocator_api,
+    const_fn,
+    alloc,
+    alloc_error_handler,
+    core_intrinsics
+)]
 extern crate alloc;
 
 /*

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
-#![feature(asm)]
+#![feature(asm, decl_macro, allocator_api, const_fn, alloc, alloc_error_handler)]
+extern crate alloc;
 
 /*
  * This selects the correct module to include depending on the architecture we're compiling the
@@ -15,8 +16,12 @@ cfg_if! {
     }
 }
 
+mod heap_allocator;
+use crate::heap_allocator::LockedHoleAllocator;
 use cfg_if::cfg_if;
 use core::panic::PanicInfo;
+#[global_allocator]
+pub static ALLOCATOR: LockedHoleAllocator = LockedHoleAllocator::new_uninitialized();
 
 #[panic_handler]
 #[no_mangle]

--- a/kernel/src/util/binary_pretty_print.rs
+++ b/kernel/src/util/binary_pretty_print.rs
@@ -1,0 +1,61 @@
+/*
+ * NOTE: This assumes that a byte is 8 bits long. I don't think I'll ever be insane enough to cater
+ * for an architecture where this isn't true, so I'm gonna call this platform-independent.
+ */
+
+use core::{fmt, mem};
+use num_traits::PrimInt;
+
+/// Values can be wrapped in this type when they're printed to display them as easy-to-read binary
+/// numbers. `Display` is implemented to print the value in the form `00000000-00000000`, while
+/// `Debug` will print it in the form `00000000(8)-00000000(0)` (with offsets of each byte).
+pub struct BinaryPrettyPrint<T: fmt::Binary + PrimInt>(pub T);
+
+impl<T: fmt::Binary + PrimInt> fmt::Display for BinaryPrettyPrint<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let byte_mask: T = T::from(0xff).unwrap();
+        let max_byte = mem::size_of::<T>() - 1;
+
+        for i in 0..max_byte {
+            let byte = max_byte - i;
+            write!(f, "{:>08b}-", (self.0 >> (byte * 8)) & byte_mask).unwrap();
+        }
+        write!(f, "{:>08b}", self.0 & byte_mask).unwrap();
+
+        Ok(())
+    }
+}
+
+impl<T: fmt::Binary + PrimInt> fmt::Debug for BinaryPrettyPrint<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let byte_mask: T = T::from(0xff).unwrap();
+        let max_byte = mem::size_of::<T>() - 1;
+
+        for i in 0..max_byte {
+            let byte = max_byte - i;
+            write!(
+                f,
+                "{:>08b}({})-",
+                (self.0 >> (byte * 8)) & byte_mask,
+                byte * 8
+            )
+            .unwrap();
+        }
+        write!(f, "{:>08b}(0)", self.0 & byte_mask).unwrap();
+
+        Ok(())
+    }
+}
+
+#[test]
+fn test() {
+    assert_eq!(format!("{}", BinaryPrettyPrint(0 as u8)), "00000000");
+    assert_eq!(
+        format!("{}", BinaryPrettyPrint(0 as u16)),
+        "00000000-00000000"
+    );
+    assert_eq!(
+        format!("{}", BinaryPrettyPrint(0 as u32)),
+        "00000000-00000000-00000000-00000000"
+    );
+}

--- a/kernel/src/util/math.rs
+++ b/kernel/src/util/math.rs
@@ -74,3 +74,22 @@ fn test_flooring_log2() {
     assert_eq!(flooring_log2(61), 5);
     assert_eq!(flooring_log2(4095), 11);
 }
+
+pub fn ceiling_log2(x: u64) -> u64 {
+    let x = if x.is_power_of_two() {
+        x
+    } else {
+        x.next_power_of_two()
+    };
+
+    // `x` will always be a power of two now, so log(2) == the number of trailing zeros
+    x.trailing_zeros() as u64
+}
+
+#[test]
+fn test_ceiling_log2() {
+    assert_eq!(ceiling_log2(1), 0);
+    assert_eq!(ceiling_log2(64), 6);
+    assert_eq!(ceiling_log2(61), 6);
+    assert_eq!(ceiling_log2(4095), 12);
+}

--- a/kernel/src/util/math.rs
+++ b/kernel/src/util/math.rs
@@ -1,0 +1,76 @@
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "tuning-fast_ctlz")] {
+        /// Fast integer `log2` that floors to the lower power-of-2 if `x` is not a power-of-2. `x`
+        /// must not be 0.
+        ///
+        /// ### Example
+        /// ```
+        /// assert_eq!(flooring_log2(1), 0);
+        /// assert_eq!(flooring_log2(64), 6);
+        /// assert_eq!(flooring_log2(61), 5);
+        /// assert_eq!(flooring_log2(4095), 11);
+        /// ```
+        pub fn flooring_log2(mut x: u64) -> u64 {
+            assert!(x > 0);
+
+            /*
+             * Count the number of leading zeros in the value, then subtract that from the total
+             * number of bits in the type (64 for a `u64`). This gets the first bit set, which is
+             * the largest power-of-2 component of the value.
+             */
+            return 64 - (unsafe { core::intrinsics::ctlz(x) } + 1);
+        }
+    } else {
+        /// Fast integer `log2` that floors to the lower power-of-2 if `x` is not a power-of-2. `x`
+        /// must not be 0.
+        ///
+        /// ### Example
+        /// ```
+        /// assert_eq!(flooring_log2(1), 0);
+        /// assert_eq!(flooring_log2(64), 6);
+        /// assert_eq!(flooring_log2(61), 5);
+        /// assert_eq!(flooring_log2(4095), 11);
+        /// ```
+        pub fn flooring_log2(mut x: u64) -> u64 {
+            assert!(x > 0);
+
+            /*
+             * Use a de-Bruijn-like algorithm, which should be the fastest CPU-agnostic way to find
+             * the previous power-of-2.
+             */
+            const TABLE: [u8; 64] = [
+                63,  0, 58,  1, 59, 47, 53,  2,
+                60, 39, 48, 27, 54, 33, 42,  3,
+                61, 51, 37, 40, 49, 18, 28, 20,
+                55, 30, 34, 11, 43, 14, 22,  4,
+                62, 57, 46, 52, 38, 26, 32, 41,
+                50, 36, 17, 19, 29, 10, 13, 21,
+                56, 45, 25, 31, 35, 16,  9, 12,
+                44, 24, 15,  8, 23,  7,  6,  5,
+            ];
+
+            x |= x >> 1;
+            x |= x >> 2;
+            x |= x >> 4;
+            x |= x >> 8;
+            x |= x >> 16;
+            x |= x >> 32;
+
+            /*
+             * Casting to `usize` here is fine even on 32-bit platforms because the slice is only
+             * 64 elements long anyways.
+             */
+            TABLE[((((x - (x >> 1)).wrapping_mul(0x07edd5e59a4e28c2))) >> 58) as usize] as u64
+        }
+    }
+}
+
+#[test]
+fn test_flooring_log2() {
+    assert_eq!(flooring_log2(1), 0);
+    assert_eq!(flooring_log2(64), 6);
+    assert_eq!(flooring_log2(61), 5);
+    assert_eq!(flooring_log2(4095), 11);
+}

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -1,0 +1,29 @@
+pub mod binary_pretty_print;
+pub mod math;
+
+pub use self::binary_pretty_print::BinaryPrettyPrint;
+
+/// This macro should be called at the beginning of functions that create logic errors if they are
+/// called more than once. Most commonly this is used for initialization functions.
+pub macro assert_first_call
+{
+    () =>
+    {
+        assert_first_call!("ASSERTION FAILED: function has already been called");
+    },
+
+    ($($arg:tt)+) =>
+    {{
+        fn assert_first_call()
+        {
+            use core::sync::atomic::{AtomicBool,
+                                     ATOMIC_BOOL_INIT,
+                                     Ordering};
+
+            static CALLED : AtomicBool = ATOMIC_BOOL_INIT;
+            let called = CALLED.swap(true, Ordering::Relaxed);
+            assert!(!called, $($arg)+);
+        }
+        assert_first_call();
+    }}
+}

--- a/kernel/src/x86_64/memory/buddy_allocator.rs
+++ b/kernel/src/x86_64/memory/buddy_allocator.rs
@@ -1,0 +1,158 @@
+//! One of the allocators we use to manage physical memory is the buddy allocator. With this
+//! allocator, memory is broken up into a number of blocks, each of which is a power-of-2 in size.
+//! The allocator maintains a set of bins, each with an order `n`, where each bin contains blocks
+//! blocks of size `2^n`. When an allocation is requested, and a block of the correct size is not
+//! available to fulfil that allocation, a larger block is split into two *buddy* blocks of half
+//! the size, one of which is used to satisfy the allocation, or is split recursively until it's
+//! the correct size. When a block is freed, the buddy is queried, and if it's free, the blocks are
+//! coalesced again into a larger block.
+//!
+//! TODO: talk about the advantages of this allocator and how the allocator scheme could be
+//! improved in the future
+
+use crate::util::math::{ceiling_log2, flooring_log2};
+use alloc::collections::BTreeSet;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::min;
+use core::ops::Range;
+use log::trace;
+use x86_64::memory::{paging::Frame, PhysicalAddress};
+
+pub struct BuddyAllocator {
+    /// The bins of free blocks, where bin `i` contains blocks of size `2^i`. Uses `BTreeSet` to
+    /// store the blocks in each bin, for efficient buddy location. The `Frame` stored for each
+    /// block is the first frame in that block - the end frame can be calculated from the start
+    /// frame and the order of the bin the block is in.
+    // TODO: when generic constants are a thing, we might be able to use `[BTreeSet; N]` here.
+    bins: Vec<BTreeSet<Frame>>,
+}
+
+impl BuddyAllocator {
+    /// Create a new `BuddyAllocator`, with a maximum block size of `2^max_order`.
+    pub fn new(max_order: usize) -> BuddyAllocator {
+        BuddyAllocator {
+            bins: vec![BTreeSet::new(); max_order + 1],
+        }
+    }
+
+    /// Add a range of `Frame`s to this allocator, marking them free to allocate.
+    pub fn add_range(&mut self, range: Range<Frame>) {
+        /*
+         * Break the frame area into a set of blocks with power-of-2 sizes, and register each block
+         * as free to allocate.
+         */
+        let mut block_start = range.start;
+
+        while block_start < range.end {
+            let order = min(
+                self.max_order(),
+                flooring_log2(
+                    usize::from(range.end.start_address()) as u64
+                        - usize::from(block_start.start_address()) as u64,
+                ) as usize,
+            );
+            trace!(
+                "Buddy allocator: adding block that starts at {:#x} of order {}",
+                block_start.start_address(),
+                order
+            );
+            self.free_n(block_start, 1 << order);
+            block_start += (1 << order);
+        }
+    }
+
+    /// Allocate (at least) `n` contiguous frames from this allocator. Returns `None` if this
+    /// allocator can't satisfy the allocation.
+    pub fn allocate_n(&mut self, n: usize) -> Option<Frame> {
+        /*
+         * Work out the size of block we need to fit `n` frames by rounding up to the next
+         * power-of-2, then recursively try and allocate a block of that order.
+         */
+        let block_order = ceiling_log2(n as u64);
+        self.allocate_block(block_order as usize)
+    }
+
+    /// Free the given block (starting at `start` and of size `n` frames). `n` must be a
+    /// power-of-2.
+    pub fn free_n(&mut self, start_frame: Frame, n: usize) {
+        trace!(
+            "Freeing block starting at {:#x} with size {}",
+            start_frame.start_address(),
+            n
+        );
+        assert!(n.is_power_of_two());
+        let order = flooring_log2(n as u64) as usize;
+
+        if order == self.max_order() {
+            /*
+             * Blocks of the maximum order can't be coalesced, because there isn't a bigger bin to
+             * put them into.
+             */
+            self.bins[order].insert(start_frame);
+            return;
+        }
+
+        /*
+         * Check if this block's buddy is also free. If it is, remove it and coalesce the blocks
+         * by recursively freeing at the order above this one.
+         */
+        let buddy = BuddyAllocator::buddy_of(start_frame, order);
+        if self.bins[order].remove(&buddy) {
+            let big_block = min(start_frame, buddy);
+            self.free_n(start_frame, 1 << (order + 1));
+        } else {
+            /*
+             * The buddy isn't free, insert the block at this order.
+             */
+            self.bins[order].insert(start_frame);
+        }
+    }
+
+    /// Tries to allocate a block of the given order. If no blocks of the correct size are
+    /// available, tries to recursively split a larger block to form a block of the requested size.
+    fn allocate_block(&mut self, order: usize) -> Option<Frame> {
+        /*
+         * We've been asked for a block larger than the largest blocks we track, so we won't be
+         * able to allocate a single block large enough.
+         */
+        if order > self.max_order() {
+            return None;
+        }
+
+        /*
+         * If that order's bin has any free blocks, use one of those.
+         */
+        if let Some(&block) = self.bins[order].iter().next() {
+            return self.bins[order].take(&block);
+        }
+
+        /*
+         * Otherwise, try to allocate a block of the order one larger, and split it in two.
+         */
+        if let Some(block) = self.allocate_block(order + 1) {
+            let second_half = BuddyAllocator::buddy_of(block, order);
+            self.free_n(second_half, 1 << order);
+            Some(block)
+        } else {
+            /*
+             * This allocator doesn't have any blocks that are able to satify the request.
+             */
+            None
+        }
+    }
+
+    /// Finds the starting frame of the block that is the buddy of the block of order `order`,
+    /// starting at `x`.
+    fn buddy_of(x: Frame, order: usize) -> Frame {
+        // TODO: work out how this works and document it
+        Frame::contains(
+            PhysicalAddress::new(usize::from(x.start_address()) ^ (1 << order)).unwrap(),
+        )
+    }
+
+    /// Get the order of the largest block this allocator can track.
+    fn max_order(&self) -> usize {
+        self.bins.len() - 1
+    }
+}

--- a/kernel/src/x86_64/memory/mod.rs
+++ b/kernel/src/x86_64/memory/mod.rs
@@ -1,0 +1,53 @@
+//! This module contains the physical memory manager Pebble uses on x86_64.
+
+mod buddy_allocator;
+
+use self::buddy_allocator::BuddyAllocator;
+use core::ops::Range;
+use spin::Mutex;
+use x86_64::boot::BootInfo;
+use x86_64::memory::paging::{Frame, FrameAllocator};
+
+const BUDDY_ALLOCATOR_MAX_ORDER: usize = 10;
+
+pub struct MemoryController {
+    pub buddy_allocator: BuddyAllocator,
+}
+
+impl MemoryController {
+    pub fn new(boot_info: &BootInfo) -> MemoryController {
+        let mut buddy_allocator = BuddyAllocator::new(BUDDY_ALLOCATOR_MAX_ORDER);
+
+        for entry in boot_info.memory_entries() {
+            if entry.memory_type == x86_64::boot::MemoryType::Conventional {
+                buddy_allocator.add_range(entry.area.clone());
+            }
+        }
+
+        MemoryController { buddy_allocator }
+    }
+}
+
+pub struct LockedMemoryController(Mutex<MemoryController>);
+
+impl LockedMemoryController {
+    pub fn new(boot_info: &BootInfo) -> LockedMemoryController {
+        LockedMemoryController(Mutex::new(MemoryController::new(boot_info)))
+    }
+}
+
+impl FrameAllocator for LockedMemoryController {
+    fn allocate_n(&self, n: usize) -> Range<Frame> {
+        let start = self
+            .0
+            .lock()
+            .buddy_allocator
+            .allocate_n(n)
+            .expect("Failed to allocate of physical memory");
+        start..(start + n)
+    }
+
+    fn free_n(&self, start: Frame, n: usize) {
+        self.0.lock().buddy_allocator.free_n(start, n);
+    }
+}

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -22,6 +22,7 @@ pub fn kmain() -> ! {
      * Initialise the heap allocator. After this, the kernel is free to use collections etc. that
      * can allocate on the heap through the global allocator.
      */
+    #[cfg(not(test))]
     unsafe {
         crate::ALLOCATOR
             .lock()

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -1,8 +1,10 @@
 //! This module defines the kernel entry-point on x86_64.
 
 mod logger;
+mod memory;
 
 use self::logger::KernelLogger;
+use self::memory::LockedMemoryController;
 use log::info;
 use x86_64::boot::BootInfo;
 use x86_64::memory::kernel_map;
@@ -37,6 +39,8 @@ pub fn kmain() -> ! {
     if boot_info.magic != x86_64::boot::BOOT_INFO_MAGIC {
         panic!("Boot info magic number is not correct!");
     }
+
+    let memory_controller = LockedMemoryController::new(boot_info);
 
     loop {}
 }

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -5,6 +5,7 @@ mod logger;
 use self::logger::KernelLogger;
 use log::info;
 use x86_64::boot::BootInfo;
+use x86_64::memory::kernel_map;
 
 /// This is the entry point for the kernel on x86_64. It is called from the UEFI bootloader and
 /// initialises the system, then passes control into the common part of the kernel.
@@ -16,6 +17,16 @@ pub extern "C" fn kmain(boot_info: &BootInfo) -> ! {
     log::set_logger(&KernelLogger).unwrap();
     log::set_max_level(log::LevelFilter::Trace);
     info!("The Pebble kernel is running");
+
+    /*
+     * Initialise the heap allocator. After this, the kernel is free to use collections etc. that
+     * can allocate on the heap through the global allocator.
+     */
+    unsafe {
+        crate::ALLOCATOR
+            .lock()
+            .init(kernel_map::HEAP_START, kernel_map::HEAP_END);
+    }
 
     loop {}
 }

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -10,7 +10,7 @@ use x86_64::memory::kernel_map;
 /// This is the entry point for the kernel on x86_64. It is called from the UEFI bootloader and
 /// initialises the system, then passes control into the common part of the kernel.
 #[no_mangle]
-pub extern "C" fn kmain(boot_info: &BootInfo) -> ! {
+pub fn kmain() -> ! {
     /*
      * Initialise the logger.
      */
@@ -26,6 +26,15 @@ pub extern "C" fn kmain(boot_info: &BootInfo) -> ! {
         crate::ALLOCATOR
             .lock()
             .init(kernel_map::HEAP_START, kernel_map::HEAP_END);
+    }
+
+    /*
+     * Retrieve the `BootInfo` passed to us from the bootloader and make sure it has the correct
+     * magic number.
+     */
+    let boot_info = unsafe { &mut *(kernel_map::BOOT_INFO.mut_ptr::<BootInfo>()) };
+    if boot_info.magic != x86_64::boot::BOOT_INFO_MAGIC {
+        panic!("Boot info magic number is not correct!");
     }
 
     loop {}

--- a/x86_64/src/boot.rs
+++ b/x86_64/src/boot.rs
@@ -1,4 +1,67 @@
+use crate::memory::paging::Frame;
+use core::ops::Range;
+
+pub const BOOT_INFO_MAGIC: u32 = 0xcafebabe;
+pub const MEMORY_MAP_NUM_ENTRIES: usize = 64;
+
+#[derive(Debug)]
+pub enum MemoryType {
+    /// Memory used by the UEFI services. Cannot be used by the OS.
+    UefiServices,
+
+    /// Conventional memory that can freely be used by the OS,
+    Conventional,
+
+    /// Memory that contains ACPI tables. After the OS has parsed the ACPI tables, it can use this
+    /// memory as if it was `Conventional`.
+    AcpiReclaimable,
+
+    /// This marks memory that the OS should preserve in the working and S1-S3 sleep states.
+    SleepPreserve,
+
+    /// This marks memory that the OS should preserve in the working and S1-S4 sleep states.
+    NonVolatileSleepPreserve,
+
+    /// Memory the bootloader has mapped the kernel image into. The OS should not use it, or it
+    /// will corrupt its own code or data.
+    KernelImage,
+
+    /// Memory the bootloader has used for the page tables containing the kernel's mapping. The OS
+    /// should not use this memory, unless it has permanently switched to another set of page
+    /// tables.
+    KernelPageTables,
+
+    /// Memory the bootloader has mapped for use as the kernel heap. The OS should not use this
+    /// memory, except as heap space.
+    KernelHeap,
+
+    /// Memory used for storing the `BootInfo` by the bootloader. It can be used by the OS after it
+    /// has finished with the information passed to it from the bootloader.
+    BootInfo,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct MemoryEntry {
+    pub area: Range<Frame>,
+    pub memory_type: MemoryType,
+}
+
 /// This structure is placed in memory by the bootloader and a reference to it passed to the
 /// kernel. It allows the kernel to access information discovered by the bootloader, such as the
 /// graphics mode it switched to.
-pub struct BootInfo {}
+///
+/// The memory map only contains regions for **usable** memory. If a frame does not appear in the
+/// memory map, it can not be used by the OS at any stage.
+///
+/// It is marked `repr(C)` to give it a standarised layout. If we used Rust's layout, and built the
+/// bootloader and kernel with different compilers, the kernel could expect a different layout to
+/// the one the bootloader has laid out in memory. If Rust ever settles on a standard ABI, this can
+/// be removed.
+#[repr(C)]
+pub struct BootInfo {
+    /// This should be set to `BOOT_INFO_MAGIC` by the bootloader.
+    pub magic: u32,
+    pub memory_map: [MemoryEntry; MEMORY_MAP_NUM_ENTRIES],
+    pub num_memory_map_entries: usize,
+}

--- a/x86_64/src/boot.rs
+++ b/x86_64/src/boot.rs
@@ -1,10 +1,12 @@
+//! TODO
+
 use crate::memory::paging::Frame;
 use core::ops::Range;
 
 pub const BOOT_INFO_MAGIC: u32 = 0xcafebabe;
 pub const MEMORY_MAP_NUM_ENTRIES: usize = 64;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum MemoryType {
     /// Memory used by the UEFI services. Cannot be used by the OS.
     UefiServices,
@@ -40,6 +42,7 @@ pub enum MemoryType {
     BootInfo,
 }
 
+/// TODO
 #[derive(Debug)]
 #[repr(C)]
 pub struct MemoryEntry {
@@ -64,4 +67,10 @@ pub struct BootInfo {
     pub magic: u32,
     pub memory_map: [MemoryEntry; MEMORY_MAP_NUM_ENTRIES],
     pub num_memory_map_entries: usize,
+}
+
+impl BootInfo {
+    pub fn memory_entries(&self) -> &[MemoryEntry] {
+        &self.memory_map[0..self.num_memory_map_entries]
+    }
 }

--- a/x86_64/src/memory/kernel_map.rs
+++ b/x86_64/src/memory/kernel_map.rs
@@ -28,11 +28,11 @@ pub const P4_TABLE_ADDRESS: VirtualAddress = VirtualAddress::from_page_table_off
 pub const KERNEL_BASE: VirtualAddress =
     unsafe { VirtualAddress::new_unchecked(0xffff_ffff_8000_0000) };
 
-// /// This is the address of the start of the kernel heap.
+/// This is the address of the start of the kernel heap. The heap is 100 KiB.
 pub const HEAP_START: VirtualAddress =
     unsafe { VirtualAddress::new_unchecked(0xffff_ffff_c000_0000) };
 pub const HEAP_END: VirtualAddress =
-    unsafe { VirtualAddress::new_unchecked(0xffff_ffff_cfff_ffff) };
+    unsafe { VirtualAddress::new_unchecked(0xffff_ffff_c00_18fff) };
 
 /*
  * Following the heap are a bunch of random memory-mapped configuration spaces and whatnot.

--- a/x86_64/src/memory/kernel_map.rs
+++ b/x86_64/src/memory/kernel_map.rs
@@ -35,7 +35,10 @@ pub const HEAP_END: VirtualAddress =
     unsafe { VirtualAddress::new_unchecked(0xffff_ffff_c00_18fff) };
 
 /*
- * Following the heap are a bunch of random memory-mapped configuration spaces and whatnot.
+ * From here, we place a bunch of hard-coded pages for various things, such as the `BootInfo`
+ * struct and memory-mapped configuration pages and stuff.
  */
-pub const LOCAL_APIC_CONFIG_PAGE: VirtualAddress =
+pub const BOOT_INFO: VirtualAddress =
     unsafe { VirtualAddress::new_unchecked(0xffff_ffff_d000_0000) };
+pub const LOCAL_APIC_CONFIG_PAGE: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0xffff_ffff_d000_1000) };

--- a/x86_64/src/memory/paging/entry.rs
+++ b/x86_64/src/memory/paging/entry.rs
@@ -59,7 +59,7 @@ impl Entry {
              * Safe to unwrap because we check that the address is valid when we create the entry
              */
             Some(Frame::contains(
-                PhysicalAddress::new(self.0 & ADDRESS_MASK).unwrap(),
+                PhysicalAddress::new((self.0 & ADDRESS_MASK) as usize).unwrap(),
             ))
         } else {
             None
@@ -67,6 +67,6 @@ impl Entry {
     }
 
     pub fn set(&mut self, frame: Frame, flags: EntryFlags) {
-        self.0 = u64::from(frame.start_address()) | flags.bits();
+        self.0 = usize::from(frame.start_address()) as u64 | flags.bits();
     }
 }

--- a/x86_64/src/memory/paging/frame.rs
+++ b/x86_64/src/memory/paging/frame.rs
@@ -5,13 +5,13 @@ use core::ops::{Add, AddAssign};
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Frame {
-    number: u64,
+    number: usize,
 }
 
 impl Frame {
     pub fn contains(address: PhysicalAddress) -> Frame {
         Frame {
-            number: u64::from(address) / FRAME_SIZE,
+            number: usize::from(address) / FRAME_SIZE,
         }
     }
 
@@ -20,10 +20,10 @@ impl Frame {
     }
 }
 
-impl Add<u64> for Frame {
+impl Add<usize> for Frame {
     type Output = Frame;
 
-    fn add(self, offset: u64) -> Self::Output {
+    fn add(self, offset: usize) -> Self::Output {
         assert!(PhysicalAddress::new((self.number + offset) * FRAME_SIZE).is_some());
         Frame {
             number: self.number + offset,
@@ -31,8 +31,8 @@ impl Add<u64> for Frame {
     }
 }
 
-impl AddAssign<u64> for Frame {
-    fn add_assign(&mut self, offset: u64) {
+impl AddAssign<usize> for Frame {
+    fn add_assign(&mut self, offset: usize) {
         assert!(PhysicalAddress::new((self.number + offset) * FRAME_SIZE).is_some());
         self.number += offset;
     }
@@ -67,7 +67,7 @@ impl Step for Frame {
 
     fn add_usize(&self, n: usize) -> Option<Self> {
         Some(Frame {
-            number: self.number.checked_add(n as u64)?,
+            number: self.number.checked_add(n as usize)?,
         })
     }
 }

--- a/x86_64/src/memory/paging/frame_allocator.rs
+++ b/x86_64/src/memory/paging/frame_allocator.rs
@@ -10,19 +10,17 @@ use core::ops::Range;
 /// types such as a `Mutex`. This allows structures to store a shared reference to the allocator,
 /// and deallocate their owned physical memory when they're dropped.
 pub trait FrameAllocator {
-    /// Allocate a `Frame`. If there are no remaining free frames, the allocator is free to take
-    /// measures to free physical memory, or to kernel panic. It is always safe to `unwrap` the
-    /// return value, as the `Err` branch is diverging (marking the possibility of kernel panic).
+    /// Allocate a `Frame`.
     ///
     /// By default, this calls `allocate_n(1)`, but can be overridden if an allocator can provide a
     /// more efficient method for allocating single frames.
-    fn allocate(&self) -> Result<Frame, !> {
-        self.allocate_n(1).map(|range| range.start)
+    fn allocate(&self) -> Frame {
+        self.allocate_n(1).start
     }
 
-    /// Allocate `n` contiguous `Frame`s, if possible.
-    fn allocate_n(&self, n: usize) -> Result<Range<Frame>, !>;
+    /// Allocate `n` contiguous `Frame`s.
+    fn allocate_n(&self, n: usize) -> Range<Frame>;
 
-    /// Free a previously-allocated frame, marking it available for allocation in the future.
-    fn free(&self, frame: Frame);
+    /// Free `n` frames that were previously allocated by this `FrameAllocator`.
+    fn free_n(&self, start: Frame, n: usize);
 }

--- a/x86_64/src/memory/paging/frame_allocator.rs
+++ b/x86_64/src/memory/paging/frame_allocator.rs
@@ -21,7 +21,7 @@ pub trait FrameAllocator {
     }
 
     /// Allocate `n` contiguous `Frame`s, if possible.
-    fn allocate_n(&self, n: u64) -> Result<Range<Frame>, !>;
+    fn allocate_n(&self, n: usize) -> Result<Range<Frame>, !>;
 
     /// Free a previously-allocated frame, marking it available for allocation in the future.
     fn free(&self, frame: Frame);

--- a/x86_64/src/memory/paging/mapper.rs
+++ b/x86_64/src/memory/paging/mapper.rs
@@ -29,7 +29,7 @@ impl Mapper<'static, RecursiveMapping> {
 impl<'a> Mapper<'a, IdentityMapping> {
     pub(super) unsafe fn new(p4_address: PhysicalAddress) -> Mapper<'a, IdentityMapping> {
         Mapper {
-            p4: &mut *(VirtualAddress::new_unchecked(u64::from(p4_address)).mut_ptr()),
+            p4: &mut *(VirtualAddress::new_unchecked(usize::from(p4_address)).mut_ptr()),
         }
     }
 }

--- a/x86_64/src/memory/paging/mapper.rs
+++ b/x86_64/src/memory/paging/mapper.rs
@@ -62,7 +62,7 @@ where
     where
         A: FrameAllocator,
     {
-        self.map_to(page, allocator.allocate().unwrap(), flags, allocator);
+        self.map_to(page, allocator.allocate(), flags, allocator);
     }
 
     pub fn map_to<A>(&mut self, page: Page, frame: Frame, flags: EntryFlags, allocator: &A)
@@ -108,6 +108,6 @@ where
         tlb::invalidate_page(page.start_address());
 
         // TODO: should we care about freeing empty P1s, P2s and P3s?
-        allocator.free(frame);
+        allocator.free_n(frame, 1);
     }
 }

--- a/x86_64/src/memory/paging/mod.rs
+++ b/x86_64/src/memory/paging/mod.rs
@@ -11,8 +11,8 @@ pub use self::mapper::Mapper;
 pub use self::page::Page;
 pub use core::ops::{Deref, DerefMut};
 
-pub const FRAME_SIZE: u64 = 0x1000;
-pub const PAGE_SIZE: u64 = 0x1000;
+pub const FRAME_SIZE: usize = 0x1000;
+pub const PAGE_SIZE: usize = 0x1000;
 
 use self::table::{IdentityMapping, RecursiveMapping, TableMapping};
 use super::PhysicalAddress;
@@ -66,13 +66,13 @@ impl InactivePageTable<IdentityMapping> {
     where
         N: TableMapping,
     {
-        let old_table_address = PhysicalAddress::new(read_control_reg!(cr3)).unwrap();
+        let old_table_address = PhysicalAddress::new(read_control_reg!(cr3) as usize).unwrap();
 
         unsafe {
             /*
              * NOTE: We don't need to flush the TLB here because it's cleared when CR3 changes.
              */
-            write_control_reg!(cr3, u64::from(self.p4_frame.start_address()));
+            write_control_reg!(cr3, usize::from(self.p4_frame.start_address()) as u64);
         }
 
         (
@@ -98,13 +98,13 @@ impl InactivePageTable<RecursiveMapping> {
     where
         N: TableMapping,
     {
-        let old_table_address = PhysicalAddress::new(read_control_reg!(cr3)).unwrap();
+        let old_table_address = PhysicalAddress::new(read_control_reg!(cr3) as usize).unwrap();
 
         unsafe {
             /*
              * NOTE: We don't need to flush the TLB here because it's cleared when CR3 changes.
              */
-            write_control_reg!(cr3, u64::from(self.p4_frame.start_address()));
+            write_control_reg!(cr3, usize::from(self.p4_frame.start_address()) as u64);
         }
 
         (

--- a/x86_64/src/memory/paging/page.rs
+++ b/x86_64/src/memory/paging/page.rs
@@ -6,14 +6,14 @@ use core::ops::{Add, AddAssign};
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Page {
-    number: u64,
+    number: usize,
 }
 
 impl Page {
     /// Get the page that contains the given virtual address.
     pub fn contains(address: VirtualAddress) -> Page {
         Page {
-            number: u64::from(address) / PAGE_SIZE,
+            number: usize::from(address) / PAGE_SIZE,
         }
     }
 
@@ -38,10 +38,10 @@ impl Page {
     }
 }
 
-impl Add<u64> for Page {
+impl Add<usize> for Page {
     type Output = Page;
 
-    fn add(self, offset: u64) -> Self::Output {
+    fn add(self, offset: usize) -> Self::Output {
         assert!(VirtualAddress::new((self.number + offset) * PAGE_SIZE).is_some());
         Page {
             number: self.number + offset,
@@ -49,8 +49,8 @@ impl Add<u64> for Page {
     }
 }
 
-impl AddAssign<u64> for Page {
-    fn add_assign(&mut self, offset: u64) {
+impl AddAssign<usize> for Page {
+    fn add_assign(&mut self, offset: usize) {
         assert!(VirtualAddress::new((self.number + offset) * PAGE_SIZE).is_some());
         self.number += offset;
     }
@@ -85,7 +85,7 @@ impl Step for Page {
 
     fn add_usize(&self, n: usize) -> Option<Self> {
         Some(Page {
-            number: self.number.checked_add(n as u64)?,
+            number: self.number.checked_add(n as usize)?,
         })
     }
 }

--- a/x86_64/src/memory/paging/table.rs
+++ b/x86_64/src/memory/paging/table.rs
@@ -86,7 +86,7 @@ impl TableMapping for IdentityMapping {
          */
         table[index]
             .pointed_frame()
-            .and_then(|frame| VirtualAddress::new(u64::from(frame.start_address())))
+            .and_then(|frame| VirtualAddress::new(usize::from(frame.start_address())))
     }
 }
 
@@ -107,9 +107,9 @@ impl TableMapping for RecursiveMapping {
              * XXX: This can make the address non-canonical when we shift the old address up into
              * the sign-extension bits, so we make sure to re-canonicalise it again.
              */
-            let table_address = table as *const _ as u64;
+            let table_address = table as *const _ as usize;
             Some(VirtualAddress::new_canonicalise(
-                (table_address << 9) | u64::from(index) << 12,
+                (table_address << 9) | usize::from(index) << 12,
             ))
         } else {
             None

--- a/x86_64/src/memory/paging/table.rs
+++ b/x86_64/src/memory/paging/table.rs
@@ -175,7 +175,7 @@ where
             );
 
             self.entries[index as usize].set(
-                allocator.allocate().unwrap(),
+                allocator.allocate(),
                 EntryFlags::default()
                     | EntryFlags::WRITABLE
                     | if user_accessible {

--- a/x86_64/src/memory/physical_address.rs
+++ b/x86_64/src/memory/physical_address.rs
@@ -7,13 +7,13 @@ use core::ops::{Add, Sub};
 /// 2^52
 #[derive(Clone, Copy, Default)]
 #[repr(transparent)]
-pub struct PhysicalAddress(u64);
+pub struct PhysicalAddress(usize);
 
 impl PhysicalAddress {
     // TODO: make `const` when const match is supported
-    pub fn new(address: u64) -> Option<PhysicalAddress> {
+    pub fn new(address: usize) -> Option<PhysicalAddress> {
         // This constant has to exist because we can't use expressions in a range
-        const MAX_PHYSICAL_ADDRESS: u64 = (1 << 52) - 1;
+        const MAX_PHYSICAL_ADDRESS: usize = (1 << 52) - 1;
 
         match address {
             0..=MAX_PHYSICAL_ADDRESS => Some(PhysicalAddress(address)),
@@ -21,11 +21,11 @@ impl PhysicalAddress {
         }
     }
 
-    pub const fn new_unchecked(address: u64) -> PhysicalAddress {
+    pub const fn new_unchecked(address: usize) -> PhysicalAddress {
         PhysicalAddress(address)
     }
 
-    pub const fn offset_into_frame(&self) -> u64 {
+    pub const fn offset_into_frame(&self) -> usize {
         self.0 % FRAME_SIZE
     }
 
@@ -52,24 +52,24 @@ impl fmt::Debug for PhysicalAddress {
     }
 }
 
-impl From<PhysicalAddress> for u64 {
-    fn from(address: PhysicalAddress) -> u64 {
+impl From<PhysicalAddress> for usize {
+    fn from(address: PhysicalAddress) -> usize {
         address.0
     }
 }
 
-impl Add<u64> for PhysicalAddress {
+impl Add<usize> for PhysicalAddress {
     type Output = Option<PhysicalAddress>;
 
-    fn add(self, rhs: u64) -> Self::Output {
+    fn add(self, rhs: usize) -> Self::Output {
         PhysicalAddress::new(self.0 + rhs)
     }
 }
 
-impl Sub<u64> for PhysicalAddress {
+impl Sub<usize> for PhysicalAddress {
     type Output = Option<PhysicalAddress>;
 
-    fn sub(self, rhs: u64) -> Self::Output {
+    fn sub(self, rhs: usize) -> Self::Output {
         PhysicalAddress::new(self.0 - rhs)
     }
 }

--- a/x86_64/src/memory/virtual_address.rs
+++ b/x86_64/src/memory/virtual_address.rs
@@ -101,7 +101,7 @@ impl VirtualAddress {
     /// Get the smallest address `x` with the given alignment such that `x >= self`. The alignment
     /// must be `0` or a power of two.
     pub fn align_up(&self, align: usize) -> VirtualAddress {
-        (*self + (align -1)).unwrap().align_down(align)
+        (*self + (align - 1)).unwrap().align_down(align)
     }
 
     /// Addresses are always expected by the CPU to be canonical (bits 48 to 63 are the same as bit

--- a/x86_64/src/memory/virtual_address.rs
+++ b/x86_64/src/memory/virtual_address.rs
@@ -8,7 +8,7 @@ use core::ops::{Add, Sub};
 /// `0xffff_ffff_ffff_ffff`.
 #[derive(Clone, Copy, Default)]
 #[repr(transparent)]
-pub struct VirtualAddress(u64);
+pub struct VirtualAddress(usize);
 
 impl VirtualAddress {
     /// Create a new `VirtualAddress` from the given address. If the given address is not a valid
@@ -17,7 +17,7 @@ impl VirtualAddress {
      * TODO: this should be made `const` when CTFE supports matches, then we should use it for all
      * the constants that currently use `new_unchecked`
      */
-    pub fn new(address: u64) -> Option<VirtualAddress> {
+    pub fn new(address: usize) -> Option<VirtualAddress> {
         match address {
             0x0000_0000_0000_0000..=0x0000_7fff_ffff_ffff => Some(VirtualAddress(address)),
             0xffff_8000_0000_0000..=0xffff_ffff_ffff_ffff => Some(VirtualAddress(address)),
@@ -27,13 +27,13 @@ impl VirtualAddress {
 
     /// Create a new `VirtualAddress` from the given address, which is assumed to be canonical.
     /// Unsafe because using a non-canonical address can cause General Protection faults.
-    pub const unsafe fn new_unchecked(address: u64) -> VirtualAddress {
+    pub const unsafe fn new_unchecked(address: usize) -> VirtualAddress {
         VirtualAddress(address)
     }
 
     /// Create a new `VirtualAddress` from the given address, canonicalising it if it is not
     /// already canonical, by the logic in the `VirtualAddress::canonicalise` method.
-    pub const fn new_canonicalise(address: u64) -> VirtualAddress {
+    pub const fn new_canonicalise(address: usize) -> VirtualAddress {
         VirtualAddress(address).canonicalise()
     }
 
@@ -45,11 +45,11 @@ impl VirtualAddress {
         offset: usize,
     ) -> VirtualAddress {
         VirtualAddress(
-            ((p4 as u64) << 39)
-                | ((p3 as u64) << 30)
-                | ((p2 as u64) << 21)
-                | ((p1 as u64) << 12)
-                | ((offset as u64) << 0),
+            ((p4 as usize) << 39)
+                | ((p3 as usize) << 30)
+                | ((p2 as usize) << 21)
+                | ((p1 as usize) << 12)
+                | ((offset as usize) << 0),
         )
         .canonicalise()
     }
@@ -63,19 +63,45 @@ impl VirtualAddress {
     }
 
     pub const fn offset(&self, offset: i64) -> VirtualAddress {
-        VirtualAddress(((self.0 as i64) + offset) as u64).canonicalise()
+        VirtualAddress(((self.0 as i64) + offset) as usize).canonicalise()
     }
 
     pub const fn is_page_aligned(&self) -> bool {
         self.0 % PAGE_SIZE == 0
     }
 
-    pub const fn is_aligned_to(&self, alignment: u64) -> bool {
+    pub const fn is_aligned_to(&self, alignment: usize) -> bool {
         self.0 % alignment == 0
     }
 
-    pub const fn offset_into_page(&self) -> u64 {
+    pub const fn offset_into_page(&self) -> usize {
         self.0 % PAGE_SIZE
+    }
+
+    /// Get the greatest address `x` with the given alignment such that `x <= self`. The alignment
+    /// must be `0` or a power of two.
+    pub fn align_down(&self, align: usize) -> VirtualAddress {
+        assert!(align == 0 || align.is_power_of_two());
+
+        if align == 0 {
+            *self
+        } else {
+            /*
+             * The alignment is a power of two, so we just:
+             *   e.g. align         = 0b00001000
+             *        align - 1     = 0b00000111
+             *        !(align - 1)  = 0b11111000
+             *                               ^^^ Masks the address to the address below it with the
+             *                                   correct alignment
+             */
+            VirtualAddress::new_canonicalise(self.0 & !(align - 1))
+        }
+    }
+
+    /// Get the smallest address `x` with the given alignment such that `x >= self`. The alignment
+    /// must be `0` or a power of two.
+    pub fn align_up(&self, align: usize) -> VirtualAddress {
+        (*self + (align -1)).unwrap().align_down(align)
     }
 
     /// Addresses are always expected by the CPU to be canonical (bits 48 to 63 are the same as bit
@@ -83,7 +109,7 @@ impl VirtualAddress {
     /// this function.
     pub const fn canonicalise(self) -> VirtualAddress {
         #[allow(inconsistent_digit_grouping)]
-        const SIGN_EXTENSION: u64 = 0o177777_000_000_000_000_0000;
+        const SIGN_EXTENSION: usize = 0o177777_000_000_000_000_0000;
 
         VirtualAddress((SIGN_EXTENSION * ((self.0 >> 47) & 0b1)) | (self.0 & ((1 << 48) - 1)))
     }
@@ -107,36 +133,36 @@ impl fmt::Debug for VirtualAddress {
     }
 }
 
-impl From<VirtualAddress> for u64 {
-    fn from(address: VirtualAddress) -> u64 {
+impl From<VirtualAddress> for usize {
+    fn from(address: VirtualAddress) -> usize {
         address.0
     }
 }
 
 impl<T> From<*const T> for VirtualAddress {
     fn from(ptr: *const T) -> VirtualAddress {
-        VirtualAddress::new(ptr as u64).expect("Pointer is non-canonical!")
+        VirtualAddress::new(ptr as usize).expect("Pointer is non-canonical!")
     }
 }
 
 impl<T> From<*mut T> for VirtualAddress {
     fn from(ptr: *mut T) -> VirtualAddress {
-        VirtualAddress::new(ptr as u64).expect("Pointer is non-canonical!")
+        VirtualAddress::new(ptr as usize).expect("Pointer is non-canonical!")
     }
 }
 
-impl Add<u64> for VirtualAddress {
+impl Add<usize> for VirtualAddress {
     type Output = Option<VirtualAddress>;
 
-    fn add(self, rhs: u64) -> Self::Output {
+    fn add(self, rhs: usize) -> Self::Output {
         VirtualAddress::new(self.0 + rhs)
     }
 }
 
-impl Sub<u64> for VirtualAddress {
+impl Sub<usize> for VirtualAddress {
     type Output = Option<VirtualAddress>;
 
-    fn sub(self, rhs: u64) -> Self::Output {
+    fn sub(self, rhs: usize) -> Self::Output {
         VirtualAddress::new(self.0 - rhs)
     }
 }


### PR DESCRIPTION
The new Pebble physical memory manager works slightly differently to many other kernel's PMMs, because we have the liberty of being able to allocate easily in the bootloader using the UEFI boot services.

The general idea is:
* Space for the heap is allocated by the bootloader
* The kernel is booted
* We initialise the virtual memory manager in the kernel
* We can then initialise the physical memory manager, using normal heap-allocated data structures

This makes our lives far easier because we can use Rust's standard data structures that allocate backing memory on the heap, instead of having to implement our own versions. This should hopefully mean that the physical memory manager has a much higher chance of being performant and sound.