### PR TITLE
Load and enter initial process in ring3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ kernel:
 
 userboot:
 	cargo xbuild --target=userboot/x86_64-pebble-userboot.json --manifest-path userboot/Cargo.toml
+	cp userboot/target/x86_64-pebble-userboot/debug/userboot $(BUILD_DIR)/fat/payload.elf
 
 clean:
 	cd bootloader && cargo clean

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ export BUILD_DIR ?= $(abspath ./build)
 
 RUST_GDB_INSTALL_PATH ?= ~/bin/rust-gdb/bin
 
-.PHONY: prepare bootloader kernel clean qemu gdb update fmt
+.PHONY: prepare bootloader kernel userboot clean qemu gdb update fmt
 
-pebble.img: prepare bootloader kernel
+pebble.img: prepare bootloader kernel userboot
 	# Create a temporary image for the FAT partition
 	dd if=/dev/zero of=$(BUILD_DIR)/fat.img bs=1M count=64
 	mkfs.vfat -F 32 $(BUILD_DIR)/fat.img -n BOOT
@@ -31,6 +31,9 @@ bootloader:
 kernel:
 	cargo xbuild --target=kernel/src/$(ARCH)/$(ARCH)-kernel.json --manifest-path kernel/Cargo.toml --features arch_$(ARCH)
 	ld --gc-sections -T kernel/src/$(ARCH)/link.ld -o $(BUILD_DIR)/fat/kernel.elf kernel/target/$(ARCH)-kernel/debug/libkernel.a
+
+userboot:
+	cargo xbuild --target=userboot/x86_64-pebble-userboot.json --manifest-path userboot/Cargo.toml
 
 clean:
 	cd bootloader && cargo clean

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -94,7 +94,7 @@ pub extern "win64" fn efi_main(image_handle: Handle, system_table: &'static Syst
     );
     let mut mapper = page_table.mapper();
 
-    let kernel_info = match load_kernel(image_handle, &mut mapper, &allocator) {
+    let kernel_info = match load_kernel(&mut mapper, &allocator) {
         Ok(kernel_info) => kernel_info,
         Err(err) => panic!("Failed to load kernel: {:?}", err),
     };
@@ -354,90 +354,122 @@ fn construct_boot_info(boot_info: &mut BootInfo, memory_map: &MemoryMap) {
     }
 }
 
-fn load_kernel(
-    image_handle: Handle,
-    mapper: &mut Mapper<IdentityMapping>,
-    allocator: &BootFrameAllocator,
-) -> Result<KernelInfo, Status> {
-    println!("Loading kernel image from boot volume");
-    let file_data = protocols::read_file("kernel.elf", image_handle)
-        .map_err(|err| panic!("Failed to read kernel ELF from disk: {:?}", err))
+struct ImageInfo<'a> {
+    pub physical_base: PhysicalAddress,
+    pub elf: Elf<'a>,
+}
+
+/// Loads an ELF from the given path on the boot volume, allocates physical memory for it, and
+/// copies its sections into the new memory. Calls `f` for each section that space is allocated
+/// for, so the caller can e.g. map it into the virtual address space, if needed.
+///
+/// This borrows the file data, instead of reading the file itself, so that it can return the
+/// loaded `Elf` back to the caller.
+fn load_image<'a>(
+    path: &str,
+    image_data: &'a [u8],
+    memory_type: MemoryType,
+    mut f: impl FnMut(PhysicalAddress, &SectionHeader),
+) -> Result<ImageInfo<'a>, Status> {
+    let elf = Elf::new(&image_data)
+        .map_err(|err| panic!("Failed to parse ELF({}): {:?}", path, err))
         .unwrap();
 
-    let elf = Elf::new(&file_data)
-        .map_err(|err| panic!("Failed to parse kernel ELF: {:?}", err))
-        .unwrap();
+    /*
+     * Work out how much space we need and check it's a multiple of the page size.
+     */
+    let image_size =
+        elf.sections().fold(
+            0,
+            |size, section| {
+                if section.is_allocated() {
+                    size + section.size
+                } else {
+                    size
+                }
+            },
+        ) as usize;
 
-    // Work out how much space we need for the kernel and check it's a multiple of the page size
-    let kernel_size = elf.sections().fold(0, |kernel_size, section| {
-        if section.is_allocated() {
-            kernel_size + section.size
-        } else {
-            kernel_size
-        }
-    }) as usize;
-
-    if kernel_size % FRAME_SIZE != 0 {
-        panic!("Kernel size is not a multiple of frame size: {:#x}!", kernel_size);
+    if image_size % FRAME_SIZE != 0 {
+        panic!("Image size is not a multiple of the frame size: {}", path);
     }
 
-    // Allocate physical memory for the kernel
-    let kernel_physical_base = system_table()
+    /*
+     * Allocate enough memory and zero it.
+     */
+    let physical_base = system_table()
         .boot_services
-        .allocate_frames(MemoryType::PebbleKernelMemory, kernel_size / FRAME_SIZE)
-        .map_err(|err| panic!("Failed to allocate physical memory for kernel: {:?}", err))
+        .allocate_frames(memory_type, image_size / FRAME_SIZE)
+        .map_err(|err| panic!("Failed to allocate memory for image({}): {:?}", path, err))
         .unwrap();
 
-    // We now zero all the kernel memory
     unsafe {
         system_table().boot_services.set_mem(
-            usize::from(kernel_physical_base) as *mut _,
-            kernel_size as usize,
+            usize::from(physical_base) as *mut _,
+            image_size as usize,
             0,
         );
     }
 
     /*
-     * We now copy the sections from the ELF image into memory, after which we can free the
-     * kernel ELF. We use sections instead of segments (as are traditionally used when
-     * loading a program) because sections allow us to define permissions for pages much more
-     * accurately. When mapping by program headers, we often end up with an executable
-     * `.data`, or a writable `.rodata`, which is less safe.
+     * Load the sections of the ELF into memory, after which we can free the ELF. We use sections
+     * instead of segments because it allows us to define permissions on a per-section basis.
      */
-    let mut physical_address = kernel_physical_base;
+    let mut section_physical_address = physical_base;
 
     for section in elf.sections() {
-        // Skip sections that shouldn't be loaded or ones with no data
+        // Skip sections that shouln't be loaded or ones with no data
         if !section.is_allocated() || section.size == 0 {
             continue;
         }
 
         println!(
-            "Loading section: '{}' at {:#x}-{:#x} from physical address {:#x} onwards",
+            "Loading section of image {}: '{}' at {:#x}-{:#x} at physical address {:#x}",
+            path,
             section.name(&elf).unwrap(),
             section.address,
             section.address + section.size - 1,
-            physical_address
+            section_physical_address,
         );
 
-        map_section(mapper, physical_address, &section, allocator);
+        f(section_physical_address, &section);
 
         /*
-         * For ProgBits sections, we need to copy the data from the image into the section. For
-         * NoBits sections, we can leave it as initialised 0s.
+         * For `ProgBits` sections, we copy the data from the image into the section's new home.
+         * For `NoBits` sections, we leave it zeroed.
          */
         if let SectionType::ProgBits = section.section_type() {
             unsafe {
                 slice::from_raw_parts_mut(
-                    usize::from(physical_address) as *mut u8,
+                    usize::from(section_physical_address) as *mut u8,
                     section.size as usize,
                 )
                 .copy_from_slice(section.data(&elf).unwrap());
             }
         }
 
-        physical_address = (physical_address + section.size as usize).unwrap();
+        section_physical_address = (section_physical_address + section.size as usize).unwrap();
     }
+
+    Ok(ImageInfo { physical_base, elf })
+}
+
+fn load_kernel(
+    mapper: &mut Mapper<IdentityMapping>,
+    allocator: &BootFrameAllocator,
+) -> Result<KernelInfo, Status> {
+    const KERNEL_PATH: &str = "kernel.elf";
+
+    /*
+     * Load the kernel ELF and map it into the page tables.
+     */
+    let file_data = protocols::read_file(KERNEL_PATH, image_handle())?;
+    let image = load_image(
+        KERNEL_PATH,
+        &file_data,
+        MemoryType::PebbleKernelMemory,
+        |section_base, section| map_section(mapper, section_base, section, allocator),
+    )?;
 
     /*
      * We now set up the kernel stack. As part of the `.bss` section, it has already had memory
@@ -445,7 +477,7 @@ fn load_kernel(
      * and unmap the guard page, and extract the address of the top of the stack.
      */
     let guard_page_address =
-        match elf.symbols().find(|symbol| symbol.name(&elf) == Some("_guard_page")) {
+        match image.elf.symbols().find(|symbol| symbol.name(&image.elf) == Some("_guard_page")) {
             Some(symbol) => VirtualAddress::new(symbol.value as usize).unwrap(),
             None => panic!("Kernel does not have a '_guard_page' symbol!"),
         };
@@ -453,13 +485,14 @@ fn load_kernel(
     println!("Unmapping guard page");
     mapper.unmap(Page::contains(guard_page_address), allocator);
 
-    let stack_top = match elf.symbols().find(|symbol| symbol.name(&elf) == Some("_stack_top")) {
-        Some(symbol) => VirtualAddress::new(symbol.value as usize).unwrap(),
-        None => panic!("Kernel does not have a '_stack_top' symbol"),
-    };
+    let stack_top =
+        match image.elf.symbols().find(|symbol| symbol.name(&image.elf) == Some("_stack_top")) {
+            Some(symbol) => VirtualAddress::new(symbol.value as usize).unwrap(),
+            None => panic!("Kernel does not have a '_stack_top' symbol"),
+        };
     assert!(stack_top.is_page_aligned(), "Stack is not page aligned");
 
-    Ok(KernelInfo { entry_point: VirtualAddress::new(elf.entry_point()).unwrap(), stack_top })
+    Ok(KernelInfo { entry_point: VirtualAddress::new(image.elf.entry_point()).unwrap(), stack_top })
 }
 
 fn map_section(

--- a/bootloader/src/memory.rs
+++ b/bootloader/src/memory.rs
@@ -175,4 +175,5 @@ pub enum MemoryType {
     PebblePageTables = 0x8000_0001,
     PebbleBootInformation = 0x8000_0002,
     PebbleKernelHeap = 0x8000_0003,
+    PebblePayloadMemory = 0x8000_0004,
 }

--- a/kernel/src/x86_64/memory/buddy_allocator.rs
+++ b/kernel/src/x86_64/memory/buddy_allocator.rs
@@ -11,10 +11,7 @@
 //! improved in the future
 
 use crate::util::math::{ceiling_log2, flooring_log2};
-use alloc::{
-    collections::BTreeSet,
-    vec::{self, Vec},
-};
+use alloc::{collections::BTreeSet, vec::Vec};
 use core::{cmp::min, ops::Range};
 use x86_64::memory::{paging::Frame, PhysicalAddress};
 

--- a/kernel/src/x86_64/memory/mod.rs
+++ b/kernel/src/x86_64/memory/mod.rs
@@ -7,7 +7,6 @@ use self::physical::LockedPhysicalMemoryManager;
 use crate::util::bitmap::Bitmap;
 use alloc::collections::BTreeMap;
 use bit_field::BitField;
-use log::info;
 use x86_64::memory::{
     kernel_map,
     paging::{

--- a/kernel/src/x86_64/memory/mod.rs
+++ b/kernel/src/x86_64/memory/mod.rs
@@ -2,6 +2,7 @@
 
 mod buddy_allocator;
 pub mod physical;
+pub mod userspace_map;
 
 use self::physical::LockedPhysicalMemoryManager;
 use crate::util::bitmap::Bitmap;

--- a/kernel/src/x86_64/memory/userspace_map.rs
+++ b/kernel/src/x86_64/memory/userspace_map.rs
@@ -1,0 +1,22 @@
+use x86_64::memory::{paging::PAGE_SIZE, VirtualAddress};
+
+pub const KERNEL_SPACE_START: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0xffffffff_80000000) };
+pub const KERNEL_SPACE_END: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0xffffffff_ffffffff) };
+
+pub const INITIAL_STACK_SIZE: usize = PAGE_SIZE;
+
+pub const MEMORY_OBJECTS_START: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0x00000005_00000000) };
+pub const MESSAGE_BUFFERS_START: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0x00000004_00000000) };
+pub const KERNEL_STACKS_START: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0x00000003_00000000) };
+pub const USER_STACKS_START: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0x00000002_00000000) };
+pub const HEAP_START: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0x00000001_00000000) };
+
+pub const IMAGE_START: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0x00000000_00010000) };

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -27,7 +27,7 @@ use x86_64::{
     },
     memory::{
         kernel_map,
-        paging::{table::RecursiveMapping, ActivePageTable},
+        paging::{table::RecursiveMapping, ActivePageTable, Frame, InactivePageTable},
     },
 };
 
@@ -104,7 +104,6 @@ pub fn kmain() -> ! {
         physical_memory_manager: LockedPhysicalMemoryManager::new(boot_info),
         kernel_page_table: Mutex::new(unsafe { ActivePageTable::<RecursiveMapping>::new() }),
         physical_region_mapper: Mutex::new(PhysicalRegionMapper::new()),
-        // gdt: Gdt::empty(),
     };
 
     let mut acpi_handler = PebbleAcpiHandler::new(
@@ -204,5 +203,10 @@ pub fn kmain() -> ! {
         None
     };
 
+    let process_page_table = unsafe {
+        InactivePageTable::<RecursiveMapping>::new(Frame::contains(
+            boot_info.payload.page_table_address,
+        ))
+    };
     crate::kernel_main(&arch)
 }

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -136,7 +136,7 @@ pub fn kmain() -> ! {
     /*
      * Register all the CPUs we can find.
      */
-    let (boot_processor, application_processors) = match acpi_info {
+    let (mut boot_processor, application_processors) = match acpi_info {
         Some(ref info) => {
             assert!(
                 info.boot_processor().is_some()
@@ -210,7 +210,10 @@ pub fn kmain() -> ! {
             boot_info.payload.page_table_address,
         ))
     };
-    let process = Process::new(&arch, process_page_table, boot_info.payload.entry_point);
+    let mut process = Process::new(&arch, process_page_table, boot_info.payload.entry_point);
 
-    crate::kernel_main(&arch)
+    info!("Dropping to usermode");
+    process::drop_to_usermode(&mut boot_processor.tss, &mut process);
+
+    // crate::kernel_main(&arch)
 }

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -5,6 +5,7 @@ mod cpu;
 mod interrupts;
 mod logger;
 mod memory;
+mod process;
 
 use self::{
     acpi_handler::PebbleAcpiHandler,
@@ -12,6 +13,7 @@ use self::{
     interrupts::InterruptController,
     logger::KernelLogger,
     memory::{physical::LockedPhysicalMemoryManager, KernelPageTable, PhysicalRegionMapper},
+    process::Process,
 };
 use crate::arch::Architecture;
 use acpi::{AmlNamespace, ProcessorState};
@@ -208,5 +210,7 @@ pub fn kmain() -> ! {
             boot_info.payload.page_table_address,
         ))
     };
+    let process = Process::new(&arch, process_page_table, boot_info.payload.entry_point);
+
     crate::kernel_main(&arch)
 }

--- a/kernel/src/x86_64/process.rs
+++ b/kernel/src/x86_64/process.rs
@@ -1,19 +1,26 @@
 use super::{memory::userspace_map::*, Arch};
 use alloc::vec::Vec;
 use log::info;
-use x86_64::memory::{
-    kernel_map::KERNEL_P4_ENTRY,
-    paging::{
-        entry::EntryFlags,
-        table::RecursiveMapping,
-        ActivePageTable,
-        InactivePageTable,
-        Page,
+use x86_64::{
+    hw::tss::Tss,
+    memory::{
+        kernel_map::KERNEL_P4_ENTRY,
+        paging::{
+            entry::EntryFlags,
+            table::RecursiveMapping,
+            ActivePageTable,
+            InactivePageTable,
+            Page,
+        },
+        VirtualAddress,
     },
-    VirtualAddress,
 };
 
 pub enum ProcessState {
+    /// We put a process in the `Poisoned` state while we do work to move it between real states
+    /// (e.g. switching to its address space when moving between `NotRunning` and `Running`). This
+    /// makes sure we can detect when something went wrong when transistioning between states.
+    Poisoned,
     NotRunning(InactivePageTable<RecursiveMapping>),
     Running(ActivePageTable<RecursiveMapping>),
 }
@@ -92,11 +99,104 @@ impl Process {
 
         Process { state: ProcessState::NotRunning(page_table), threads: vec![main_thread] }
     }
+
+    pub fn switch_to(&mut self) {
+        use core::mem;
+
+        self.state = match mem::replace(&mut self.state, ProcessState::Poisoned) {
+            ProcessState::NotRunning(inactive_table) => {
+                /*
+                 * XXX: `RecursiveMapping` is correct here because we'll always be switching from
+                 * either the kernel's or another process' page tables.
+                 */
+                ProcessState::Running(unsafe { inactive_table.switch_to::<RecursiveMapping>().0 })
+            }
+
+            ProcessState::Running(_) => {
+                panic!("Tried to switch to a process that is already running!")
+            }
+            ProcessState::Poisoned => panic!("Tried to switch to a poisoned process!"),
+        };
+    }
 }
 
 /// Drop to Ring 3, into a process. This is used for the initial transition from kernel to user
 /// mode after the CPU has been brought up.
-pub fn drop_to_usermode(arch: &Arch, process: &mut Process) -> ! {
-    // TODO
-    unimplemented!();
+pub fn drop_to_usermode(tss: &mut Tss, process: &mut Process) -> ! {
+    use x86_64::hw::gdt::{USER_CODE_SELECTOR, USER_DATA_SELECTOR};
+
+    unsafe {
+        /*
+         * Disable interrupts so we aren't interrupted in the middle of this. They are
+         * re-enabled on the `iret`.
+         */
+        asm!("cli");
+
+        /*
+         * Save the current kernel stack pointer in the TSS.
+         */
+        let rsp: VirtualAddress;
+        asm!(""
+         : "={rsp}"(rsp)
+         :
+         : "rsp"
+         : "intel"
+        );
+        tss.set_kernel_stack(rsp);
+
+        /*
+         * Switch to the process' address space.
+         */
+        process.switch_to();
+
+        /*
+         * Jump into Ring 3 by constructing a fake interrupt frame, then returning from the
+         * "interrupt".
+         */
+        asm!("// Push selector for user data segment
+              push rax
+
+              // Push new stack pointer
+              push rbx
+
+              // Push new RFLAGS. We set this to the bare minimum to avoid leaking flags out of the
+              // kernel. Bit 2 must be one, and we enable interrupts by setting bit 9.
+              push rcx
+
+              // Push selector for user code segment
+              push rdx
+
+              // Push new instruction pointer
+              push rsi
+
+              // Zero all the things
+              xor rax, rax
+              xor rbx, rbx
+              xor rcx, rcx
+              xor rdx, rdx
+              xor rsi, rsi
+              xor rdi, rdi
+              xor r8, r8
+              xor r9, r9
+              xor r10, r10
+              xor r11, r11
+              xor r12, r12
+              xor r13, r13
+              xor r14, r14
+              xor r15, r15
+
+              // Return from our fake interrupt frame
+              iretq
+              "
+        :
+        : "{rax}"(USER_DATA_SELECTOR),
+          "{rbx}"(process.threads[0].stack_pointer),
+          "{rcx}"(1<<9 | 1<<2),
+          "{rdx}"(USER_CODE_SELECTOR),
+          "{rsi}"(process.threads[0].instruction_pointer)
+        : "rax", "rbx", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"
+        : "intel"
+        );
+        unreachable!();
+    }
 }

--- a/kernel/src/x86_64/process.rs
+++ b/kernel/src/x86_64/process.rs
@@ -1,0 +1,102 @@
+use super::{memory::userspace_map::*, Arch};
+use alloc::vec::Vec;
+use log::info;
+use x86_64::memory::{
+    kernel_map::KERNEL_P4_ENTRY,
+    paging::{
+        entry::EntryFlags,
+        table::RecursiveMapping,
+        ActivePageTable,
+        InactivePageTable,
+        Page,
+    },
+    VirtualAddress,
+};
+
+pub enum ProcessState {
+    NotRunning(InactivePageTable<RecursiveMapping>),
+    Running(ActivePageTable<RecursiveMapping>),
+}
+
+/// Represents a thread, including its stack and the contents of RIP, RSP, and RBP. The rest of the
+/// registers are pushed to the stack when a context switch occurs.
+pub struct Thread {
+    pub id: u8,
+
+    pub stack_top: VirtualAddress,
+    pub stack_size: usize,
+
+    pub instruction_pointer: VirtualAddress,
+    pub stack_pointer: VirtualAddress,
+    pub base_pointer: VirtualAddress,
+}
+
+pub struct Process {
+    state: ProcessState,
+    threads: Vec<Thread>,
+}
+
+impl Process {
+    pub fn new(
+        arch: &Arch,
+        mut page_table: InactivePageTable<RecursiveMapping>,
+        entry_point: VirtualAddress,
+    ) -> Process {
+        /*
+         * NOTE: safe to unwrap because we wouldn't be able to fetch these instructions if the
+         * kernel wasn't mapped.
+         */
+        let kernel_p3_frame =
+            arch.kernel_page_table.lock().p4[KERNEL_P4_ENTRY].pointed_frame().unwrap();
+
+        /*
+         * Because the main thread is id 0, its stacks are at the beginning of the relevant
+         * areas.
+         */
+        let stack_bottom = USER_STACKS_START;
+        let stack_top = (stack_bottom + INITIAL_STACK_SIZE).unwrap();
+
+        arch.kernel_page_table.lock().with(
+            &mut page_table,
+            &arch.physical_memory_manager,
+            |mapper, allocator| {
+                /*
+                 * We map the kernel into every process' address space by stealing the address of
+                 * the kernel's P3, and putting it into the process' P4.
+                 */
+                mapper.p4[KERNEL_P4_ENTRY]
+                    .set(kernel_p3_frame, EntryFlags::PRESENT | EntryFlags::WRITABLE);
+
+                /*
+                 * Map the main thread's stack.
+                 */
+                mapper.map_range(
+                    Page::contains(stack_bottom)..Page::contains(stack_top),
+                    EntryFlags::PRESENT
+                        | EntryFlags::WRITABLE
+                        | EntryFlags::NO_EXECUTE
+                        | EntryFlags::USER_ACCESSIBLE,
+                    allocator,
+                );
+            },
+        );
+
+        let main_thread = Thread {
+            id: 0,
+            stack_top,
+            stack_size: INITIAL_STACK_SIZE,
+            instruction_pointer: entry_point,
+            stack_pointer: stack_top,
+            base_pointer: stack_top,
+        };
+
+        Process { state: ProcessState::NotRunning(page_table), threads: vec![main_thread] }
+    }
+}
+
+/// Drop to Ring 3, into a process. This is used for the initial transition from kernel to user
+/// mode after the CPU has been brought up.
+pub fn drop_to_usermode(arch: &Arch, process: &mut Process) -> ! {
+    // TODO
+    unimplemented!();
+}

--- a/userboot/Cargo.lock
+++ b/userboot/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "userboot"
+version = "0.1.0"
+

--- a/userboot/Cargo.toml
+++ b/userboot/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "userboot"
+version = "0.1.0"
+authors = ["Isaac Woods"]
+edition = "2018"
+
+[dependencies]
+
+[profile.dev]
+debug = false
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/userboot/link.ld
+++ b/userboot/link.ld
@@ -1,0 +1,26 @@
+ENTRY(start)
+OUTPUT_FORMAT(elf64-x86-64)
+
+SECTIONS {
+    . = 0x10000;
+
+    .text : {
+        *(.text)
+        . = ALIGN(4K);
+    }
+
+    .rodata : {
+        *(.rodata .rodata.*)
+        . = ALIGN(4K);
+    }
+
+    .data : {
+        *(.data .data.*)
+        . = ALIGN(4K);
+    }
+
+    .bss : {
+        *(.bss .bss.*)
+        . = ALIGN(4K);
+    }
+}

--- a/userboot/src/main.rs
+++ b/userboot/src/main.rs
@@ -1,0 +1,18 @@
+#![no_std]
+#![no_main]
+#![feature(asm)]
+
+use core::panic::PanicInfo;
+
+#[no_mangle]
+pub extern "C" fn start() -> ! {
+    unsafe {
+        asm!("mov rax, 0xdeadbeef" :::: "intel");
+    }
+    loop {}
+}
+
+#[panic_handler]
+pub fn handle_panic(_: &PanicInfo) -> ! {
+    loop {}
+}

--- a/userboot/x86_64-pebble-userboot.json
+++ b/userboot/x86_64-pebble-userboot.json
@@ -1,0 +1,16 @@
+{
+  "llvm-target": "x86_64-unknown-none",
+  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "arch": "x86_64",
+  "target-endian": "little",
+  "target-pointer-width": "64",
+  "target-c-int-width": "32",
+  "os": "none",
+  "executables": true,
+  "linker-flavor": "ld",
+  "linker": "ld.lld",
+  "pre-link-args": { "ld": ["-Tlink.ld"] },
+  "panic-strategy": "abort",
+  "disable-redzone": true,
+  "features": "-mmx,-sse,+soft-float"
+}

--- a/x86_64/src/boot.rs
+++ b/x86_64/src/boot.rs
@@ -1,10 +1,6 @@
 //! TODO
 
-use crate::memory::{
-    paging::{table::IdentityMapping, Frame, InactivePageTable},
-    PhysicalAddress,
-    VirtualAddress,
-};
+use crate::memory::{paging::Frame, PhysicalAddress, VirtualAddress};
 use core::ops::Range;
 
 pub const BOOT_INFO_MAGIC: u32 = 0xcafebabe;
@@ -70,7 +66,10 @@ impl Default for MemoryEntry {
 #[repr(C)]
 pub struct PayloadInfo {
     pub entry_point: VirtualAddress,
-    pub page_table: InactivePageTable<IdentityMapping>,
+    /// The physical address of the P4 frame of the process' constructed page tables. This is
+    /// passed as an address so that the kernel can construct its own owned page table for the
+    /// process.
+    pub page_table_address: PhysicalAddress,
 }
 
 /// This structure is placed in memory by the bootloader and a reference to it passed to the

--- a/x86_64/src/boot.rs
+++ b/x86_64/src/boot.rs
@@ -1,12 +1,16 @@
 //! TODO
 
-use crate::memory::{paging::Frame, PhysicalAddress, VirtualAddress, paging::{InactivePageTable, table::IdentityMapping}};
+use crate::memory::{
+    paging::{table::IdentityMapping, Frame, InactivePageTable},
+    PhysicalAddress,
+    VirtualAddress,
+};
 use core::ops::Range;
 
 pub const BOOT_INFO_MAGIC: u32 = 0xcafebabe;
 pub const MEMORY_MAP_NUM_ENTRIES: usize = 64;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MemoryType {
     /// Memory used by the UEFI services. Cannot be used by the OS.
     UefiServices,
@@ -46,12 +50,21 @@ pub enum MemoryType {
     BootInfo,
 }
 
-/// TODO
 #[derive(Debug)]
 #[repr(C)]
 pub struct MemoryEntry {
     pub area: Range<Frame>,
     pub memory_type: MemoryType,
+}
+
+impl Default for MemoryEntry {
+    fn default() -> Self {
+        MemoryEntry {
+            area: Frame::contains(PhysicalAddress::new(0x0).unwrap())
+                ..(Frame::contains(PhysicalAddress::new(0x0).unwrap())),
+            memory_type: MemoryType::UefiServices,
+        }
+    }
 }
 
 #[repr(C)]

--- a/x86_64/src/memory/kernel_map.rs
+++ b/x86_64/src/memory/kernel_map.rs
@@ -12,9 +12,12 @@ use super::VirtualAddress;
 /// userspace and kernel portions, which is less inconvienient than it being a hole.
 pub const RECURSIVE_ENTRY: u16 = 510;
 
+/// The kernel is mapped into the 511th entry of the P4.
+pub const KERNEL_P4_ENTRY: u16 = 511;
+
 /// This address can be used to access the **currently mapped** P4 table, assuming the correct entry
 /// is recursively mapped properly.
-pub const P4_TABLE_ADDRESS: VirtualAddress = VirtualAddress::from_page_table_offsets(
+pub const P4_TABLE_RECURSIVE_ADDRESS: VirtualAddress = VirtualAddress::from_page_table_offsets(
     RECURSIVE_ENTRY,
     RECURSIVE_ENTRY,
     RECURSIVE_ENTRY,
@@ -48,8 +51,15 @@ pub const PHYSICAL_MAPPING_END: VirtualAddress =
 pub const BOOT_INFO: VirtualAddress =
     unsafe { VirtualAddress::new_unchecked(0xffff_ffff_d000_0000) };
 
+/// This address can be used to access the kernel page table's P4 table **all the time**. It does
+/// not make use of the recursive mapping, so can be used when we're modifying another set of
+/// tables by installing them into the kernel's recursive entry. This mapping is set up by the
+/// bootloader.
+pub const KERNEL_P4_START: VirtualAddress =
+    unsafe { VirtualAddress::new_unchecked(0xffff_ffff_d000_1000) };
+
 /// The virtual address that the configuration page of the local APIC is mapped to. We don't manage
 /// this using a simple `PhysicalMapping` because we need to be able to access the local APIC from
 /// interrupt handlers, which can't easily access owned `PhysicalMapping`s.
 pub const LOCAL_APIC_CONFIG: VirtualAddress =
-    unsafe { VirtualAddress::new_unchecked(0xffff_ffff_d000_1000) };
+    unsafe { VirtualAddress::new_unchecked(0xffff_ffff_d000_2000) };

--- a/x86_64/src/memory/paging/mod.rs
+++ b/x86_64/src/memory/paging/mod.rs
@@ -5,12 +5,7 @@ pub mod mapper;
 pub mod page;
 pub mod table;
 
-pub use self::{
-    frame::Frame,
-    frame_allocator::FrameAllocator,
-    mapper::Mapper,
-    page::Page,
-};
+pub use self::{frame::Frame, frame_allocator::FrameAllocator, mapper::Mapper, page::Page};
 pub use core::ops::{Deref, DerefMut};
 
 pub const FRAME_SIZE: usize = 0x1000;

--- a/x86_64/src/memory/paging/table.rs
+++ b/x86_64/src/memory/paging/table.rs
@@ -6,7 +6,10 @@ use super::{
     entry::{Entry, EntryFlags},
     FrameAllocator,
 };
-use crate::memory::{kernel_map::P4_TABLE_ADDRESS, VirtualAddress};
+use crate::memory::{
+    kernel_map::{KERNEL_P4_START, P4_TABLE_RECURSIVE_ADDRESS},
+    VirtualAddress,
+};
 use core::{
     marker::PhantomData,
     ops::{Index, IndexMut},
@@ -14,7 +17,13 @@ use core::{
 
 /// This points to the **currently installed** P4, **if** it is correctly recursively mapped. This
 /// **does not** hold in the bootloader before we install our own tables.
-pub(super) const P4: *mut Table<Level4, RecursiveMapping> = P4_TABLE_ADDRESS.mut_ptr();
+pub(super) const P4: *mut Table<Level4, RecursiveMapping> = P4_TABLE_RECURSIVE_ADDRESS.mut_ptr();
+
+/// This points to the kernel's P4 without using its recursive mapping. It is mainly used, instead
+/// of `P4`, when we've put another set of page tables' address in the kernel's table's recursive
+/// entry, so we can modify those using the recursive mapping.
+pub(super) const KERNEL_P4_NON_RECURSIVE: *mut Table<Level4, RecursiveMapping> =
+    KERNEL_P4_START.mut_ptr();
 
 pub enum Level4 {}
 pub enum Level3 {}


### PR DESCRIPTION
Because Pebble's kernel doesn't have any concept of files or a ramdisk, we load the initial usermode process in the bootloader from the boot volume - the bootloader refers to this as the "kernel payload".

In minimalist distributions, this payload could be the only usermode process, and a filesystem wouldn't even be needed. More commonly, a process called `userboot` is started, which has a ramdisk containing other programs embedded into its image. `userboot` creates processes from each of the images in its ramdisk (probably including processes to manage the VFS and any supported filesystems), then exits.

In the meantime, `userboot` will be used as a testing ground for developing Pebble's usermode services. This PR just aims to load an image into memory, create page tables for it, and enter Ring 3 into it.