### PR TITLE
Add support for the `syscall` instruction

### DIFF
--- a/bootloader/Cargo.toml
+++ b/bootloader/Cargo.toml
@@ -12,7 +12,6 @@ x86_64 = { path = "../x86_64" }
 
 [profile.release]
 debug = true
-lto = "thin"
 
 [package.metadata.cargo-xbuild]
 memcpy = true

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -235,6 +235,7 @@ fn setup_for_kernel() {
     }
 
     let mut efer = read_msr!(x86_64::hw::registers::EFER);
+    efer |= 1 << 0; // Enable the syscall and sysret instructions
     efer |= 1 << 8; // Enable long mode
     efer |= 1 << 11; // Enable use of the NX bit in the page tables
     unsafe {

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -234,12 +234,12 @@ fn setup_for_kernel() {
         write_control_reg!(CR4, cr4);
     }
 
-    let mut efer = read_msr!(x86_64::hw::registers::EFER);
+    let mut efer = read_msr(x86_64::hw::registers::EFER);
     efer |= 1 << 0; // Enable the syscall and sysret instructions
     efer |= 1 << 8; // Enable long mode
     efer |= 1 << 11; // Enable use of the NX bit in the page tables
     unsafe {
-        write_msr!(x86_64::hw::registers::EFER, efer);
+        write_msr(x86_64::hw::registers::EFER, efer);
     }
 }
 

--- a/kernel/src/x86_64/interrupts.rs
+++ b/kernel/src/x86_64/interrupts.rs
@@ -1,8 +1,8 @@
 use super::Arch;
 use crate::util::binary_pretty_print::BinaryPrettyPrint;
 use acpi::interrupt::InterruptModel;
-use log::{error, info};
 use bit_field::BitField;
+use log::{error, info};
 use x86_64::{
     hw::{
         gdt::KERNEL_CODE_SELECTOR,
@@ -126,9 +126,11 @@ impl InterruptController {
          *
          * Refer to the documentation comments of each MSR to understand what this code is doing.
          */
-        use x86_64::hw::registers::{IA32_STAR, IA32_LSTAR, IA32_FMASK};
-        use x86_64::hw::gdt::{USER_COMPAT_CODE_SELECTOR};
         use crate::x86_64::process::yield_handler;
+        use x86_64::hw::{
+            gdt::USER_COMPAT_CODE_SELECTOR,
+            registers::{IA32_FMASK, IA32_LSTAR, IA32_STAR},
+        };
 
         let mut selectors = 0_u64;
         selectors.set_bits(32..48, KERNEL_CODE_SELECTOR.0 as u64);

--- a/kernel/src/x86_64/process.rs
+++ b/kernel/src/x86_64/process.rs
@@ -200,3 +200,12 @@ pub fn drop_to_usermode(tss: &mut Tss, process: &mut Process) -> ! {
         unreachable!();
     }
 }
+
+/// This is called when a task yields to the kernel (using `syscall`, on x86_64). Tasks yield when
+/// they have no work to do / are waiting on another process to respond to a message etc. The
+/// kernel should handle any messages the yielding task has sent, and then schedule another task.
+// TODO: think about how we're going to access stuff from here (very annoying). We need to be able
+// to dispatch messages etc. (ideally we kinda want to get access to the whole `Arch`).
+pub extern "C" fn yield_handler() {
+    info!("Task yielded!");
+}

--- a/kernel/src/x86_64/process.rs
+++ b/kernel/src/x86_64/process.rs
@@ -123,7 +123,7 @@ impl Process {
 /// Drop to Ring 3, into a process. This is used for the initial transition from kernel to user
 /// mode after the CPU has been brought up.
 pub fn drop_to_usermode(tss: &mut Tss, process: &mut Process) -> ! {
-    use x86_64::hw::gdt::{USER_CODE_SELECTOR, USER_DATA_SELECTOR};
+    use x86_64::hw::gdt::{USER_CODE64_SELECTOR, USER_DATA_SELECTOR};
 
     unsafe {
         /*
@@ -192,7 +192,7 @@ pub fn drop_to_usermode(tss: &mut Tss, process: &mut Process) -> ! {
         : "{rax}"(USER_DATA_SELECTOR),
           "{rbx}"(process.threads[0].stack_pointer),
           "{rcx}"(1<<9 | 1<<2),
-          "{rdx}"(USER_CODE_SELECTOR),
+          "{rdx}"(USER_CODE64_SELECTOR),
           "{rsi}"(process.threads[0].instruction_pointer)
         : "rax", "rbx", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"
         : "intel"

--- a/userboot/src/main.rs
+++ b/userboot/src/main.rs
@@ -8,6 +8,8 @@ use core::panic::PanicInfo;
 pub extern "C" fn start() -> ! {
     unsafe {
         asm!("mov rax, 0xdeadbeef" :::: "intel");
+        asm!("syscall");
+        asm!("mov rax, 0xcafebabe" :::: "intel");
     }
     loop {}
 }

--- a/x86_64/src/hw/gdt.rs
+++ b/x86_64/src/hw/gdt.rs
@@ -96,7 +96,8 @@ impl TssSegment {
 
 pub const KERNEL_CODE_SELECTOR: SegmentSelector = SegmentSelector::new(1, PrivilegeLevel::Ring0);
 pub const KERNEL_DATA_SELECTOR: SegmentSelector = SegmentSelector::new(2, PrivilegeLevel::Ring0);
-pub const USER_COMPAT_CODE_SELECTOR: SegmentSelector = SegmentSelector::new(3, PrivilegeLevel::Ring3);
+pub const USER_COMPAT_CODE_SELECTOR: SegmentSelector =
+    SegmentSelector::new(3, PrivilegeLevel::Ring3);
 pub const USER_DATA_SELECTOR: SegmentSelector = SegmentSelector::new(4, PrivilegeLevel::Ring3);
 pub const USER_CODE64_SELECTOR: SegmentSelector = SegmentSelector::new(5, PrivilegeLevel::Ring3);
 pub const BOOTSTRAP_TSS_SELECTOR: SegmentSelector = SegmentSelector::new(6, PrivilegeLevel::Ring0);

--- a/x86_64/src/hw/gdt.rs
+++ b/x86_64/src/hw/gdt.rs
@@ -96,24 +96,30 @@ impl TssSegment {
 
 pub const KERNEL_CODE_SELECTOR: SegmentSelector = SegmentSelector::new(1, PrivilegeLevel::Ring0);
 pub const KERNEL_DATA_SELECTOR: SegmentSelector = SegmentSelector::new(2, PrivilegeLevel::Ring0);
-pub const USER_CODE_SELECTOR: SegmentSelector = SegmentSelector::new(3, PrivilegeLevel::Ring3);
+pub const USER_COMPAT_CODE_SELECTOR: SegmentSelector = SegmentSelector::new(3, PrivilegeLevel::Ring3);
 pub const USER_DATA_SELECTOR: SegmentSelector = SegmentSelector::new(4, PrivilegeLevel::Ring3);
-pub const BOOTSTRAP_TSS_SELECTOR: SegmentSelector = SegmentSelector::new(5, PrivilegeLevel::Ring0);
+pub const USER_CODE64_SELECTOR: SegmentSelector = SegmentSelector::new(5, PrivilegeLevel::Ring3);
+pub const BOOTSTRAP_TSS_SELECTOR: SegmentSelector = SegmentSelector::new(6, PrivilegeLevel::Ring0);
 
 // NOTE: this includes the null segment
-pub const NUM_STATIC_ENTRIES: usize = 6;
+pub const NUM_STATIC_ENTRIES: usize = 7;
 pub const MAX_CPUS: usize = 8;
 
-/// A GDT suitable for the kernel to use. It contains two code segments, one for Ring 0 and another
-/// for Ring 3. While data segments still exist on x86_64, they are useless, so we instead just
-/// load the selector for the null segment into the data segments.
+/// A GDT suitable for the kernel to use. The order of the segments is important: `sysret` relies
+/// on the Ring-3 segments going in the order "32-bit Code Segment", "Data Segment", "64-bit Code
+/// Segment".
 #[repr(C, packed)]
 pub struct Gdt {
     null: u64,
     kernel_code: CodeSegment,
     kernel_data: DataSegment,
-    user_code: CodeSegment,
+
+    /// This is a placeholder segment for returning to Ring 3 in Compatability Mode. We don't
+    /// support this so this is just set to a null segment.
+    user_compat_code: u64,
     user_data: DataSegment,
+    user_code64: CodeSegment,
+
     tsss: [TssSegment; MAX_CPUS],
 
     /// This field is not part of the actual GDT; we just use it to keep track of how many TSS
@@ -130,8 +136,9 @@ impl Gdt {
             null: 0,
             kernel_code: CodeSegment::new(PrivilegeLevel::Ring0),
             kernel_data: DataSegment::new(PrivilegeLevel::Ring0),
-            user_code: CodeSegment::new(PrivilegeLevel::Ring3),
+            user_compat_code: 0,
             user_data: DataSegment::new(PrivilegeLevel::Ring3),
+            user_code64: CodeSegment::new(PrivilegeLevel::Ring3),
             tsss: [TssSegment::empty(); MAX_CPUS],
             next_free_tss: 0,
         }

--- a/x86_64/src/hw/registers.rs
+++ b/x86_64/src/hw/registers.rs
@@ -79,7 +79,23 @@ pub macro write_control_reg($reg: ident, $value: expr) {
         );
 }
 
-pub const EFER: u32 = 0xC0000080;
+pub const EFER: u32 = 0xc0000080;
+
+/// Contains the Ring 0 and Ring 3 code-segment selectors loaded by `syscall` and `sysret`,
+/// respectively:
+/// * `syscall` loads bits 32-47 into CS (so this should be the Ring 0 code-segment)
+/// * `sysret` loads bits 48-63 into CS (so this should be the Ring 3 code-segment)
+///
+/// These instructions assume that the data-segment for each ring is directly after the
+/// code-segment.
+pub const IA32_STAR: u32 = 0xc0000081;
+
+/// Contains the virtual address of the handler to call upon `syscall`.
+pub const IA32_LSTAR: u32 = 0xc0000082;
+
+/// Upon `syscall`, the value of this MSR is used to mask `RFLAGS`. Specifically, if a bit is set
+/// in this MSR, that bit in RFLAGS is zerod.
+pub const IA32_FMASK: u32 = 0xc0000084;
 
 /// Read from a model-specific register.
 pub fn read_msr(reg: u32) -> u64 {

--- a/x86_64/src/hw/registers.rs
+++ b/x86_64/src/hw/registers.rs
@@ -102,11 +102,11 @@ pub fn read_msr(reg: u32) -> u64 {
     let (high, low): (u32, u32);
     unsafe {
         asm!("rdmsr"
-             : "={eax}"(low), "={edx}"(high)
-             : "{ecx}"(reg)
-             : "memory"
-             : "volatile"
-            );
+         : "={eax}"(low), "={edx}"(high)
+         : "{ecx}"(reg)
+         : "memory"
+         : "volatile"
+        );
     }
     ((high as u64) << 32 | (low as u64))
 }
@@ -117,9 +117,9 @@ pub unsafe fn write_msr(reg: u32, value: u64) {
     use bit_field::BitField;
 
     asm!("wrmsr"
-         :
-         : "{ecx}"(reg), "{eax}"(value as u32), "{edx}"(value.get_bits(32..64) as u32)
-         : "memory"
-         : "volatile"
-        );
+     :
+     : "{ecx}"(reg), "{eax}"(value as u32), "{edx}"(value.get_bits(32..64) as u32)
+     : "memory"
+     : "volatile"
+    );
 }


### PR DESCRIPTION
On x86_64, we want to use the `syscall` instruction to yield from a userspace task back into the kernel, so it can schedule another task. This sets up all the machinery to use the instruction.