### PR TITLE
Make working with addresses easier

### DIFF
--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -247,7 +247,7 @@ fn allocate_and_map_heap(mapper: &mut Mapper<IdentityMapping>, allocator: &BootF
     println!("Allocating memory for kernel heap");
 
     assert!(kernel_map::HEAP_START.is_page_aligned());
-    assert!((kernel_map::HEAP_END + 1).unwrap().is_page_aligned());
+    assert!((kernel_map::HEAP_END + 1).is_page_aligned());
     let heap_size = (usize::from(kernel_map::HEAP_END) + 1) - usize::from(kernel_map::HEAP_START);
     assert!(heap_size % FRAME_SIZE == 0);
     let heap_physical_base = system_table()
@@ -570,8 +570,8 @@ fn map_section(
      */
     let frames =
         Frame::contains(physical_base)..Frame::contains(physical_base + section.size as usize);
-    let pages = Page::contains(virtual_address)
-        ..Page::contains((virtual_address + section.size as usize).unwrap());
+    let pages =
+        Page::contains(virtual_address)..Page::contains(virtual_address + section.size as usize);
     assert!(frames.clone().count() == pages.clone().count());
 
     /*

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -256,8 +256,8 @@ fn allocate_and_map_heap(mapper: &mut Mapper<IdentityMapping>, allocator: &BootF
         .map_err(|err| panic!("Failed to allocate memory for kernel heap: {:?}", err))
         .unwrap();
 
-    let heap_frames = Frame::contains(heap_physical_base)
-        ..=Frame::contains((heap_physical_base + heap_size).unwrap());
+    let heap_frames =
+        Frame::contains(heap_physical_base)..=Frame::contains(heap_physical_base + heap_size);
     let heap_pages = Page::contains(kernel_map::HEAP_START)..=Page::contains(kernel_map::HEAP_END);
     for (frame, page) in heap_frames.zip(heap_pages) {
         mapper.map_to(
@@ -478,7 +478,7 @@ fn load_image<'a>(
             }
         }
 
-        section_physical_address = (section_physical_address + section.size as usize).unwrap();
+        section_physical_address += section.size as usize;
     }
 
     Ok(ImageInfo { physical_base, elf })
@@ -568,8 +568,8 @@ fn map_section(
      * physical_base + size)` and `[virtual_address, virtual_address + size)` gives us the
      * correct frame and page ranges.
      */
-    let frames = Frame::contains(physical_base)
-        ..Frame::contains((physical_base + section.size as usize).unwrap());
+    let frames =
+        Frame::contains(physical_base)..Frame::contains(physical_base + section.size as usize);
     let pages = Page::contains(virtual_address)
         ..Page::contains((virtual_address + section.size as usize).unwrap());
     assert!(frames.clone().count() == pages.clone().count());

--- a/kernel/src/x86_64/memory/mod.rs
+++ b/kernel/src/x86_64/memory/mod.rs
@@ -97,7 +97,7 @@ impl PhysicalRegionMapper {
         frame_allocator: &LockedPhysicalMemoryManager,
     ) {
         for page in Page::contains(mapping.virtual_base)
-            ..Page::contains((mapping.virtual_base + mapping.size).unwrap())
+            ..Page::contains(mapping.virtual_base + mapping.size)
         {
             // Unmap it from the virtual address space
             page_tables.unmap(page, frame_allocator);

--- a/kernel/src/x86_64/process.rs
+++ b/kernel/src/x86_64/process.rs
@@ -61,7 +61,7 @@ impl Process {
          * areas.
          */
         let stack_bottom = USER_STACKS_START;
-        let stack_top = (stack_bottom + INITIAL_STACK_SIZE).unwrap();
+        let stack_top = stack_bottom + INITIAL_STACK_SIZE;
 
         arch.kernel_page_table.lock().with(
             &mut page_table,

--- a/x86_64/src/memory/paging/mapper.rs
+++ b/x86_64/src/memory/paging/mapper.rs
@@ -44,7 +44,10 @@ where
     /// Get the `PhysicalAddress` a given `VirtualAddress` is mapped to by these page tables, if
     /// it's mapped. If these page tables don't map it to any physical frame, this returns `None`.
     pub fn translate(&self, address: VirtualAddress) -> Option<PhysicalAddress> {
-        self.translate_page(Page::contains(address))?.start_address() + address.offset_into_page()
+        Some(
+            self.translate_page(Page::contains(address))?.start_address()
+                + address.offset_into_page(),
+        )
     }
 
     /// Get the physical `Frame` that a given virtual `Page` is mapped to, if it's mapped.

--- a/x86_64/src/memory/physical_address.rs
+++ b/x86_64/src/memory/physical_address.rs
@@ -2,7 +2,7 @@ use super::paging::FRAME_SIZE;
 use core::{
     cmp::Ordering,
     fmt,
-    ops::{Add, Sub},
+    ops::{Add, AddAssign, Sub, SubAssign},
 };
 
 /// Represents an address in the physical memory space. A valid physical address is smaller than
@@ -61,18 +61,42 @@ impl From<PhysicalAddress> for usize {
 }
 
 impl Add<usize> for PhysicalAddress {
-    type Output = Option<PhysicalAddress>;
+    type Output = PhysicalAddress;
 
     fn add(self, rhs: usize) -> Self::Output {
-        PhysicalAddress::new(self.0 + rhs)
+        match PhysicalAddress::new(self.0 + rhs) {
+            Some(address) => address,
+            None => panic!(
+                "Physical address arithmetic led to invalid address: {:#x} + {:#x}",
+                self, rhs
+            ),
+        }
+    }
+}
+
+impl AddAssign<usize> for PhysicalAddress {
+    fn add_assign(&mut self, rhs: usize) {
+        *self = *self + rhs;
     }
 }
 
 impl Sub<usize> for PhysicalAddress {
-    type Output = Option<PhysicalAddress>;
+    type Output = PhysicalAddress;
 
     fn sub(self, rhs: usize) -> Self::Output {
-        PhysicalAddress::new(self.0 - rhs)
+        match PhysicalAddress::new(self.0 - rhs) {
+            Some(address) => address,
+            None => panic!(
+                "Physical address arithmetic led to invalid address: {:#x} - {:#x}",
+                self, rhs
+            ),
+        }
+    }
+}
+
+impl SubAssign<usize> for PhysicalAddress {
+    fn sub_assign(&mut self, rhs: usize) {
+        *self = *self - rhs;
     }
 }
 

--- a/x86_64/src/memory/virtual_address.rs
+++ b/x86_64/src/memory/virtual_address.rs
@@ -2,7 +2,7 @@ use super::paging::PAGE_SIZE;
 use core::{
     cmp::Ordering,
     fmt,
-    ops::{Add, Sub},
+    ops::{Add, AddAssign, Sub, SubAssign},
 };
 
 /// Represents a canonical virtual address. To be canonical, the address must be in the ranges
@@ -103,7 +103,7 @@ impl VirtualAddress {
     /// Get the smallest address `x` with the given alignment such that `x >= self`. The alignment
     /// must be `0` or a power of two.
     pub fn align_up(&self, align: usize) -> VirtualAddress {
-        (*self + (align - 1)).unwrap().align_down(align)
+        (*self + (align - 1)).align_down(align)
     }
 
     /// Addresses are always expected by the CPU to be canonical (bits 48 to 63 are the same as bit
@@ -153,19 +153,31 @@ impl<T> From<*mut T> for VirtualAddress {
     }
 }
 
+impl AddAssign<usize> for VirtualAddress {
+    fn add_assign(&mut self, rhs: usize) {
+        *self = *self + rhs;
+    }
+}
+
 impl Add<usize> for VirtualAddress {
-    type Output = Option<VirtualAddress>;
+    type Output = VirtualAddress;
 
     fn add(self, rhs: usize) -> Self::Output {
-        VirtualAddress::new(self.0 + rhs)
+        VirtualAddress::new_canonicalise(self.0 + rhs)
     }
 }
 
 impl Sub<usize> for VirtualAddress {
-    type Output = Option<VirtualAddress>;
+    type Output = VirtualAddress;
 
     fn sub(self, rhs: usize) -> Self::Output {
-        VirtualAddress::new(self.0 - rhs)
+        VirtualAddress::new_canonicalise(self.0 - rhs)
+    }
+}
+
+impl SubAssign<usize> for VirtualAddress {
+    fn sub_assign(&mut self, rhs: usize) {
+        *self = *self - rhs;
     }
 }
 


### PR DESCRIPTION
Fix #21 

We have just ended up with `unwrap` scattered about when dealing with arithmetic with the address types, because it's quite tedious to actually handle the errors.

* `PhysicalAddress` now panics if arithmetic produces an invalid address
* `VirtualAddress` re-canonicalises the address if arithmetic invalidates the sign-extension.